### PR TITLE
Dsf-MV-Integration: Proof of concept

### DIFF
--- a/org.eclipse.tracecompass.dsf.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.tracecompass.dsf.core/META-INF/MANIFEST.MF
@@ -17,3 +17,4 @@ Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Export-Package: org.eclipse.tracecompass.internal.dsf.core;x-friends:="org.eclipse.tracecompass.tmf.ui",
  org.eclipse.tracecompass.internal.dsf.core.service;x-internal:=true
+Import-Package: org.eclipse.jdt.annotation

--- a/org.eclipse.tracecompass.dsf.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.tracecompass.dsf.core/META-INF/MANIFEST.MF
@@ -11,6 +11,7 @@ Require-Bundle: org.eclipse.cdt.dsf,
  org.eclipse.osgi,
  org.eclipse.equinox.common,
  org.eclipse.core.runtime,
+ org.eclipse.tracecompass.lttng2.kernel.core;bundle-version="0.1.0",
  org.eclipse.tracecompass.tmf.core
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/org.eclipse.tracecompass.dsf.core/src/org/eclipse/tracecompass/internal/dsf/core/DsfTraceSessionManager.java
+++ b/org.eclipse.tracecompass.dsf.core/src/org/eclipse/tracecompass/internal/dsf/core/DsfTraceSessionManager.java
@@ -35,12 +35,12 @@ public class DsfTraceSessionManager {
      * Create a DSF session f
      * @return The DSF session created.
      */
-    public static DsfSession startDsfSession() {
+    public static DsfSession startDsfSession(ITmfTrace trace) {
         final DefaultDsfExecutor dsfExecutor = new DefaultDsfExecutor(TRACE_DEBUG_MODEL_ID);
         dsfExecutor.prestartCoreThread();
         DsfSession session = DsfSession.startSession(dsfExecutor, TRACE_DEBUG_MODEL_ID);
 
-        startServices(session);
+        startServices(session, trace);
 
         return session;
     }
@@ -58,14 +58,14 @@ public class DsfTraceSessionManager {
         return null;
     }
 
-    private static void startServices(final DsfSession session) {
+    private static void startServices(final DsfSession session, final ITmfTrace trace) {
         Query<Object> query = new Query<Object>() {
             @Override
             protected void execute(final DataRequestMonitor<Object> rm) {
                 new TraceCommandControlService(session).initialize(new ImmediateRequestMonitor(rm) {
                     @Override
                     protected void handleSuccess() {
-                        new TraceHardwareAndOSService(session).initialize(new ImmediateRequestMonitor(rm));
+                        new TraceHardwareAndOSService(session, trace).initialize(new ImmediateRequestMonitor(rm));
                     }
                 });
             }

--- a/org.eclipse.tracecompass.dsf.core/src/org/eclipse/tracecompass/internal/dsf/core/service/TraceHardwareAndOSService.java
+++ b/org.eclipse.tracecompass.dsf.core/src/org/eclipse/tracecompass/internal/dsf/core/service/TraceHardwareAndOSService.java
@@ -10,7 +10,9 @@
  *******************************************************************************/
 package org.eclipse.tracecompass.internal.dsf.core.service;
 
+import java.util.HashMap;
 import java.util.Hashtable;
+import java.util.List;
 import java.util.Map;
 
 import org.eclipse.cdt.dsf.concurrent.DataRequestMonitor;
@@ -26,10 +28,16 @@ import org.eclipse.cdt.dsf.gdb.service.IGDBHardwareAndOS;
 import org.eclipse.cdt.dsf.gdb.service.IGDBHardwareAndOS2;
 import org.eclipse.cdt.dsf.service.AbstractDsfService;
 import org.eclipse.cdt.dsf.service.DsfSession;
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
+import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.tracecompass.internal.dsf.core.DsfTraceCorePlugin;
+import org.eclipse.tracecompass.internal.lttng2.kernel.core.Attributes;
 import org.eclipse.tracecompass.lttng2.kernel.core.analysis.cpuusage.LttngKernelCpuUsageAnalysis;
+import org.eclipse.tracecompass.statesystem.core.ITmfStateSystem;
+import org.eclipse.tracecompass.statesystem.core.exceptions.AttributeNotFoundException;
+import org.eclipse.tracecompass.statesystem.core.exceptions.TimeRangeException;
 import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
 import org.eclipse.tracecompass.tmf.core.trace.TmfTraceUtils;
 import org.osgi.framework.BundleContext;
@@ -39,132 +47,178 @@ public class TraceHardwareAndOSService extends AbstractDsfService implements IGD
 
     final private ITmfTrace fTrace;
     final private LttngKernelCpuUsageAnalysis fCPUModule;
+    final private ITmfStateSystem fStateSys;
+    final private Map<ICPUDMContext, ICoreDMContext[]> fMapCPUToCores = new HashMap<>();
 
-	@Immutable
-	private static class GDBCPUDMC extends AbstractDMContext
-	implements ICPUDMContext
-	{
-		/**
-		 * String ID that is used to identify the thread in the GDB/MI protocol.
-		 */
-		private final String fId;
+    @Immutable
+    private static class GDBCPUDMC extends AbstractDMContext
+            implements ICPUDMContext
+    {
+        /**
+         * String ID that is used to identify the thread in the GDB/MI protocol.
+         */
+        private final String fId;
 
-		/**
-		 * @param sessionId The session
-		 * @param targetDmc The target
-		 * @param id the CPU id
-		 */
+        /**
+         * @param sessionId
+         *            The session
+         * @param targetDmc
+         *            The target
+         * @param id
+         *            the CPU id
+         */
         protected GDBCPUDMC(String sessionId, IHardwareTargetDMContext targetDmc, String id) {
             super(sessionId, targetDmc == null ? new IDMContext[0] : new IDMContext[] { targetDmc });
             fId = id;
         }
 
-		@Override
-		public String getId(){
-			return fId;
-		}
+        @Override
+        public String getId() {
+            return fId;
+        }
 
-		@Override
-		public String toString() { return baseToString() + ".CPU[" + fId + "]"; }  //$NON-NLS-1$ //$NON-NLS-2$
+        @Override
+        public String toString() {
+            return baseToString() + ".CPU[" + fId + "]";} //$NON-NLS-1$ //$NON-NLS-2$
 
-		@Override
-		public boolean equals(Object obj) {
-			return baseEquals(obj) && ((GDBCPUDMC)obj).fId.equals(fId);
-		}
+        @Override
+        public boolean equals(Object obj) {
+            return baseEquals(obj) && ((GDBCPUDMC) obj).fId.equals(fId);
+        }
 
-		@Override
-		public int hashCode() { return baseHashCode() ^ fId.hashCode(); }
-	}
+        @Override
+        public int hashCode() {
+            return baseHashCode() ^ fId.hashCode();
+        }
+    }
 
     @Immutable
     private static class GDBCoreDMC extends AbstractDMContext
-	implements ICoreDMContext
-	{
-		private final String fId;
+            implements ICoreDMContext
+    {
+        /**
+         * E.g. The name given to the State system node representing a cpu core
+         */
+        private final String fId;
+        /**
+         * The node in the Tmftrace State system,
+         */
+        private final Integer fNode;
 
-		public GDBCoreDMC(String sessionId, ICPUDMContext CPUDmc, String id) {
-			super(sessionId, CPUDmc == null ? new IDMContext[0] : new IDMContext[] { CPUDmc });
-			fId = id;
-		}
+        public GDBCoreDMC(String sessionId, ICPUDMContext CPUDmc, Integer coreNode, String id) {
+            super(sessionId, CPUDmc == null ? new IDMContext[0] : new IDMContext[] { CPUDmc });
+            fId = id;
+            fNode = coreNode;
+        }
 
-		@Override
-		public String getId(){ return fId; }
+        @Override
+        public String getId() {
+            return fId;
+        }
 
-		@Override
-		public String toString() { return baseToString() + ".core[" + fId + "]"; }  //$NON-NLS-1$ //$NON-NLS-2$
+        // The State system node is the key to access any additional
+        // information, however the value does not represent the actual core id
+        public Integer getNode() {
+            return fNode;
+        }
 
-		@Override
-		public boolean equals(Object obj) {
-			return baseEquals(obj) &&
-			       (((GDBCoreDMC)obj).fId == null ? fId == null : ((GDBCoreDMC)obj).fId.equals(fId));
-		}
+        @Override
+        public String toString() {
+            return baseToString() + ".core[" + fId + "]";} //$NON-NLS-1$ //$NON-NLS-2$
 
-		@Override
-		public int hashCode() { return baseHashCode() ^ (fId == null ? 0 : fId.hashCode()); }
-	}
+        @Override
+        public boolean equals(Object obj) {
+            return baseEquals(obj) &&
+                    (((GDBCoreDMC) obj).fId == null ? fId == null : ((GDBCoreDMC) obj).fId.equals(fId));
+        }
 
-//    @Immutable
-//    private static class GDBCPUDMData implements ICPUDMData {
-//    	final int fNumCores;
-//
-//    	public GDBCPUDMData(int num) {
-//    		fNumCores = num;
-//    	}
-//
-//		@Override
-//		public int getNumCores() { return fNumCores; }
-//    }
-//
-//    @Immutable
-//    private static class GDBCoreDMData implements ICoreDMData {
-//    	final String fPhysicalId;
-//
-//    	public GDBCoreDMData(String id) {
-//    		fPhysicalId = id;
-//    	}
-//
-//		@Override
-//		public String getPhysicalId() { return fPhysicalId; }
-//    }
+        @Override
+        public int hashCode() {
+            return baseHashCode() ^ (fId == null ? 0 : fId.hashCode());
+        }
+    }
 
+    // @Immutable
+    // private static class GDBCPUDMData implements ICPUDMData {
+    // final int fNumCores;
+    //
+    // public GDBCPUDMData(int num) {
+    // fNumCores = num;
+    // }
+    //
+    // @Override
+    // public int getNumCores() { return fNumCores; }
+    // }
+    //
+    // @Immutable
+    // private static class GDBCoreDMData implements ICoreDMData {
+    // final String fPhysicalId;
+    //
+    // public GDBCoreDMData(String id) {
+    // fPhysicalId = id;
+    // }
+    //
+    // @Override
+    // public String getPhysicalId() { return fPhysicalId; }
+    // }
 
     @Immutable
     private class GDBLoadInfo implements ILoadInfo {
-    	private String fLoad;
-    	private Map<String,String> fDetailedLoad;
+        private int fILoad;
+        private String fLoad;
+        private Map<String, String> fDetailedLoad;
 
-    	public GDBLoadInfo(String load, Map<String,String> detailedLoad) {
-    		fLoad = load;
-   			fDetailedLoad = detailedLoad;
-    	}
-    	public GDBLoadInfo(String load) {
-    		this(load, null);
-    	}
-		@Override
-		public String getLoad() {
-			return fLoad;
-		}
-		@Override
-		public Map<String,String> getDetailedLoad() {
-			return fDetailedLoad;
-		}
+        public GDBLoadInfo(String load, Map<String, String> detailedLoad) {
+            fLoad = load;
+            fILoad = Integer.valueOf(load);
+            fDetailedLoad = detailedLoad;
+        }
+
+        public GDBLoadInfo(int load) {
+            this(String.valueOf(load), null);
+            fILoad = load;
+        }
+
+        public int getILoad() {
+            return fILoad;
+        }
+
+        @Override
+        public String getLoad() {
+            return fLoad;
+        }
+
+        @Override
+        public Map<String, String> getDetailedLoad() {
+            return fDetailedLoad;
+        }
     }
 
     /**
-     * @param session The DSF session for this service.
-     * @param trace The trace associated to this service
+     * @param session
+     *            The DSF session for this service.
+     * @param trace
+     *            The trace associated to this service
+     * @throws CoreException
      */
-    public TraceHardwareAndOSService(DsfSession session, ITmfTrace trace) {
-    	super(session);
-    	fTrace = trace;
+    public TraceHardwareAndOSService(@NonNull DsfSession session, @NonNull ITmfTrace trace) throws CoreException {
+        super(session);
+        fTrace = trace;
 
-    	//initialize cpu data source
+        // initialize cpu data source
         fCPUModule = TmfTraceUtils.getAnalysisModuleOfClass(fTrace, LttngKernelCpuUsageAnalysis.class, LttngKernelCpuUsageAnalysis.ID);
         if (fCPUModule == null) {
-            return;
+            // Notify of incorrect initialization
+            throw new CoreException(new Status(IStatus.ERROR, DsfTraceCorePlugin.PLUGIN_ID, INVALID_HANDLE, "Unable to resolve Cpu Usage Analysis module from trace: " + trace, null)); //$NON-NLS-1$
         }
+
         fCPUModule.schedule();
         fCPUModule.waitForInitialization();
+        fStateSys = fCPUModule.getStateSystem();
+        if (fStateSys == null) {
+            // Notify of incorrect initialization
+            throw new CoreException(new Status(IStatus.ERROR, DsfTraceCorePlugin.PLUGIN_ID, INVALID_HANDLE, "Unable to resolve the State System from trace: " + trace, null)); //$NON-NLS-1$
+        }
     }
 
     /**
@@ -175,123 +229,257 @@ public class TraceHardwareAndOSService extends AbstractDsfService implements IGD
      */
     @Override
     public void initialize(final RequestMonitor requestMonitor) {
-    	super.initialize(new RequestMonitor(ImmediateExecutor.getInstance(), requestMonitor) {
-    		@Override
-    		protected void handleSuccess() {
-    			doInitialize(requestMonitor);
-			}
-		});
-	}
+        super.initialize(new RequestMonitor(ImmediateExecutor.getInstance(), requestMonitor) {
+            @Override
+            protected void handleSuccess() {
+                doInitialize(requestMonitor);
+            }
+        });
+    }
 
-	/**
-	 * This method initializes this service after our superclass's initialize()
-	 * method succeeds.
-	 *
-	 * @param requestMonitor
-	 *            The call-back object to notify when this service's
-	 *            initialization is done.
-	 */
-	private void doInitialize(RequestMonitor requestMonitor) {
+    /**
+     * This method initializes this service after our superclass's initialize()
+     * method succeeds.
+     *
+     * @param requestMonitor
+     *            The call-back object to notify when this service's
+     *            initialization is done.
+     */
+    private void doInitialize(RequestMonitor requestMonitor) {
         // Register this service.
-		register(new String[] { IGDBHardwareAndOS.class.getName(),
-								IGDBHardwareAndOS2.class.getName(),
-				                TraceHardwareAndOSService.class.getName() },
-				 new Hashtable<String, String>());
+        register(new String[] { IGDBHardwareAndOS.class.getName(),
+                IGDBHardwareAndOS2.class.getName(),
+                TraceHardwareAndOSService.class.getName() },
+                new Hashtable<String, String>());
 
-		requestMonitor.done();
-	}
+        requestMonitor.done();
+    }
 
-	@Override
-	public void shutdown(RequestMonitor requestMonitor) {
-		unregister();
-		super.shutdown(requestMonitor);
-	}
+    @Override
+    public void shutdown(RequestMonitor requestMonitor) {
+        unregister();
+        super.shutdown(requestMonitor);
+    }
 
-	/**
-	 * @return The bundle context of the plug-in to which this service belongs.
-	 */
-	@Override
-	protected BundleContext getBundleContext() {
-		return DsfTraceCorePlugin.getBundleContext();
-	}
+    /**
+     * @return The bundle context of the plug-in to which this service belongs.
+     */
+    @Override
+    protected BundleContext getBundleContext() {
+        return DsfTraceCorePlugin.getBundleContext();
+    }
 
-	@Override
-	public void getCPUs(final IHardwareTargetDMContext dmc, final DataRequestMonitor<ICPUDMContext[]> rm) {
-        // TODO
-        ICPUDMContext[] cpuDmcs = new ICPUDMContext[4];
-        for (int i = 0; i < cpuDmcs.length; i++) {
-            cpuDmcs[i] = createCPUContext(dmc, Integer.toString(i));
+    @Override
+    public void getCPUs(final IHardwareTargetDMContext dmc, final DataRequestMonitor<ICPUDMContext[]> rm) {
+        // Assuming one CPU per trace for the time being
+        if (fMapCPUToCores.keySet().size() > 0) {
+            // CPU's already resolved for the associated trace
+            ICPUDMContext[] cpus = fMapCPUToCores.keySet().toArray(new ICPUDMContext[fMapCPUToCores.size()]);
+            rm.done(cpus);
+            return;
         }
 
+        // Need to resolve the associated CPU's
+        // TODO: Trace compass does not seem to divide core and cpu today,
+        // For now lets go with one CPU per HW target, and use the Trace compass
+        // CPU's as cores
+        ICPUDMContext cpuDmc = createCPUContext(dmc, "1"); //$NON-NLS-1$
+
+        ICPUDMContext[] cpuDmcs = new ICPUDMContext[] { cpuDmc };
+        System.out.println("returning " + cpuDmcs.length + " CPU");
         rm.done(cpuDmcs);
-	}
-
-	@Override
-	public void getCores(IDMContext dmc, final DataRequestMonitor<ICoreDMContext[]> rm) {
-		ICPUDMContext cpuDmc = DMContexts.getAncestorOfType(dmc, ICPUDMContext.class);
-
-		// TODO
-		if (cpuDmc == null) {
-		    IHardwareTargetDMContext targetDmc = DMContexts.getAncestorOfType(dmc, IHardwareTargetDMContext.class);
-		    cpuDmc = createCPUContext(targetDmc, "1"); //$NON-NLS-1$
-		}
-		ICoreDMContext[] coreDmcs = new ICoreDMContext[1];
-        coreDmcs[0] = createCoreContext(cpuDmc, cpuDmc.getId());
-
-        rm.done(coreDmcs);
-	}
-
-	@Override
-	public void getExecutionData(IDMContext dmc, DataRequestMonitor<IDMData> rm) {
-		if (dmc instanceof ICoreDMContext) {
-			rm.done(new Status(IStatus.ERROR, DsfTraceCorePlugin.PLUGIN_ID, NOT_SUPPORTED, "Not done yet", null)); //$NON-NLS-1$
-		} else if (dmc instanceof ICPUDMContext) {
-			rm.done(new Status(IStatus.ERROR, DsfTraceCorePlugin.PLUGIN_ID, NOT_SUPPORTED, "Not done yet", null)); //$NON-NLS-1$
-		} else {
-			rm.done(new Status(IStatus.ERROR, DsfTraceCorePlugin.PLUGIN_ID, INVALID_HANDLE, "Invalid DMC type", null)); //$NON-NLS-1$
-		}
-	}
-
-	@Override
-	public ICPUDMContext createCPUContext(IHardwareTargetDMContext targetDmc, String CPUId) {
-		return new GDBCPUDMC(getSession().getId(), targetDmc, CPUId);
-	}
-
-	@Override
-	public ICoreDMContext createCoreContext(ICPUDMContext cpuDmc, String coreId) {
-		return new GDBCoreDMC(getSession().getId(), cpuDmc, coreId);
-	}
-
-	@Override
-	public void flushCache(IDMContext context) {
-	}
-
-	@Override
-	public boolean isAvailable() {
-		return true;
-	}
-
-	@Override
-	public void getResourceClasses(IDMContext dmc,
-			DataRequestMonitor<IResourceClass[]> rm) {
-		rm.done(new Status(IStatus.ERROR, DsfTraceCorePlugin.PLUGIN_ID, NOT_SUPPORTED, "Operation not supported", null)); //$NON-NLS-1$
-	}
-
-	@Override
-	public void getResourcesInformation(IDMContext dmc, String resourceClassId,
-			DataRequestMonitor<IResourcesInformation> rm) {
-		rm.done(new Status(IStatus.ERROR, DsfTraceCorePlugin.PLUGIN_ID, NOT_SUPPORTED, "Operation not supported", null)); //$NON-NLS-1$
-	}
-
- 	@Override
-	public void getLoadInfo(final IDMContext context, final DataRequestMonitor<ILoadInfo> rm) {
-		if (!(context instanceof ICoreDMContext) && !(context instanceof ICPUDMContext)) {
-			// we only support getting the load for a CPU or a core
-			rm.done(new Status(IStatus.ERROR, DsfTraceCorePlugin.PLUGIN_ID, INVALID_HANDLE, "Load information not supported for this context type", null)); //$NON-NLS-1$
-			return;
-		}
-
-		// TODO
-		rm.done(new GDBLoadInfo("50")); //$NON-NLS-1$
     }
+
+    @Override
+    public void getCores(IDMContext dmc, final DataRequestMonitor<ICoreDMContext[]> rm) {
+        ICPUDMContext cpuDmc = DMContexts.getAncestorOfType(dmc, ICPUDMContext.class);
+
+        // Not allowed to process a context with no cpu context to force well
+        // formed contexts in any future calls
+        if (cpuDmc == null) {
+            rm.done(new Status(IStatus.ERROR, DsfTraceCorePlugin.PLUGIN_ID, INVALID_HANDLE, "Initialization problem, No ICPUDMContext found in context: " + dmc, null)); //$NON-NLS-1$
+            return;
+        }
+
+        // Check if the ICoreDMContexts exist in our cpu map
+        ICoreDMContext[] coreDmcs = fMapCPUToCores.get(cpuDmc);
+        if (coreDmcs != null) {
+            // We have previously resolved the cores, so lets return them
+            rm.done(coreDmcs);
+            return;
+        }
+
+        // Not available, so get the cores from the trace state system and cache
+        // them
+        rm.done(resolveCoreContexts(cpuDmc));
+    }
+
+    @Override
+    public void getExecutionData(IDMContext dmc, DataRequestMonitor<IDMData> rm) {
+        if (dmc instanceof ICoreDMContext) {
+            rm.done(new Status(IStatus.ERROR, DsfTraceCorePlugin.PLUGIN_ID, NOT_SUPPORTED, "Not done yet", null)); //$NON-NLS-1$
+        } else if (dmc instanceof ICPUDMContext) {
+            rm.done(new Status(IStatus.ERROR, DsfTraceCorePlugin.PLUGIN_ID, NOT_SUPPORTED, "Not done yet", null)); //$NON-NLS-1$
+        } else {
+            rm.done(new Status(IStatus.ERROR, DsfTraceCorePlugin.PLUGIN_ID, INVALID_HANDLE, "Invalid DMC type", null)); //$NON-NLS-1$
+        }
+    }
+
+    @Override
+    public ICPUDMContext createCPUContext(IHardwareTargetDMContext targetDmc, String CPUId) {
+        ICPUDMContext cpuDmc = new GDBCPUDMC(getSession().getId(), targetDmc, CPUId);
+        // Lets leave the resolution of cores to its actual call
+        fMapCPUToCores.put(cpuDmc, null);
+        return cpuDmc;
+    }
+
+    private ICoreDMContext[] resolveCoreContexts(ICPUDMContext cpuDmc) {
+        // For now treat a Trace CPU as Core
+        try {
+            int cpusNode = fStateSys.getQuarkAbsolute(Attributes.CPUS);
+            List<Integer> cpuNodes = fStateSys.getSubAttributes(cpusNode, false);
+
+            ICoreDMContext[] coreDmcs = new ICoreDMContext[cpuNodes.size()];
+            int i = 0;
+            for (Integer coreNode : cpuNodes) {
+                String cpuName = fStateSys.getAttributeName(coreNode);
+                coreDmcs[i] = createCoreContext(cpuDmc, coreNode, cpuName);
+                i++;
+                System.out.println("resolved core #" + cpuName);
+            }
+
+            fMapCPUToCores.put(cpuDmc, coreDmcs);
+            // Normal scenario, returning contexts for each core
+            System.out.println("resolved " + cpuNodes.size() + " Cores"); //$NON-NLS-1$ //$NON-NLS-2$
+
+            return coreDmcs;
+        } catch (AttributeNotFoundException e) {
+            // No core attributes found
+            return new ICoreDMContext[0];
+        }
+    }
+
+    @Override
+    public ICoreDMContext createCoreContext(ICPUDMContext cpuDmc, String coreId) {
+        // FIXME: Not being used at the moment, but need to discuss and improve
+        // the API as we need an additional element i.e. the coreNode as seen in
+        // the private method below
+        assert false;
+        return null;
+    }
+
+    /**
+     * @param cpuDmc
+     *            - Parent cpu context
+     * @param coreNode
+     *            - Reference to the state system model
+     * @param coreId
+     *            - Id displayed by the UI
+     * @return - The created core context
+     */
+    public ICoreDMContext createCoreContext(ICPUDMContext cpuDmc, Integer coreNode, String coreId) {
+        return new GDBCoreDMC(getSession().getId(), cpuDmc, coreNode, coreId);
+    }
+
+    @Override
+    public void flushCache(IDMContext context) {
+    }
+
+    @Override
+    public boolean isAvailable() {
+        return true;
+    }
+
+    @Override
+    public void getResourceClasses(IDMContext dmc,
+            DataRequestMonitor<IResourceClass[]> rm) {
+        rm.done(new Status(IStatus.ERROR, DsfTraceCorePlugin.PLUGIN_ID, NOT_SUPPORTED, "Operation not supported", null)); //$NON-NLS-1$
+    }
+
+    @Override
+    public void getResourcesInformation(IDMContext dmc, String resourceClassId,
+            DataRequestMonitor<IResourcesInformation> rm) {
+        rm.done(new Status(IStatus.ERROR, DsfTraceCorePlugin.PLUGIN_ID, NOT_SUPPORTED, "Operation not supported", null)); //$NON-NLS-1$
+    }
+
+    @Override
+    public void getLoadInfo(final IDMContext context, final DataRequestMonitor<ILoadInfo> rm) {
+        if (context instanceof ICoreDMContext) {
+            rm.done(getCoreLoadInfo((ICoreDMContext) context));
+            return;
+        }
+
+        if (context instanceof ICPUDMContext) {
+            // Resolve the load for given cpu context
+            rm.done(getCPULoadInfo((ICPUDMContext) context));
+            return;
+        }
+
+        // we only support getting the load for a CPU or a core
+        rm.done(new Status(IStatus.ERROR, DsfTraceCorePlugin.PLUGIN_ID, INVALID_HANDLE, "Load information not supported for this context type", null)); //$NON-NLS-1$
+        return;
+
+    }
+
+    private ILoadInfo getCoreLoadInfo(ICoreDMContext coreDmc) {
+        // TODO: Need to extend the API to provide the load of the current
+        // selected time, this may
+        long startTime = fStateSys.getStartTime();
+        long endTime = fStateSys.getCurrentEndTime();
+        double duration = endTime - startTime;
+
+        // validate time ranges and prevent division by zero
+        if (duration < 1) {
+            assert false;
+            throw new TimeRangeException();
+        }
+
+        // Validate context, and provide a handle to the internal class
+        // implementation
+        assert (coreDmc instanceof GDBCoreDMC);
+        GDBCoreDMC context = (GDBCoreDMC) coreDmc;
+
+        Integer[] coreNode = new Integer[] { context.getNode() };
+
+        Map<String, Long> tidToCPUTime = fCPUModule.getCpuUsageInRange(coreNode, startTime, endTime);
+        // The map from thread to time spent includes a grand total identified
+        // with the key "total"
+        double totCpuTime = tidToCPUTime.get("total"); //$NON-NLS-1$
+        String cpuName = fStateSys.getAttributeName(context.getNode());
+        // The idle time is represented by a thread id of zero over the
+        // following key=value format "cpuname/threadId=value"
+        double idleCpuTime = tidToCPUTime.get(cpuName + "/0"); //$NON-NLS-1$
+        totCpuTime = totCpuTime - idleCpuTime;
+
+        double loadPercent = (totCpuTime / duration) * 100;
+        System.out.println("Core " + context.getId() + ", load: " + (int) loadPercent);
+
+        return new GDBLoadInfo((int) loadPercent);
+    }
+
+    private ILoadInfo getCPULoadInfo(ICPUDMContext cpuDmc) {
+        int loadInfo = 0;
+
+        // Resolve the context for the cores
+        ICoreDMContext[] coreDmcs = fMapCPUToCores.get(cpuDmc);
+        if (coreDmcs == null) {
+            coreDmcs = resolveCoreContexts(cpuDmc);
+        }
+
+        if (coreDmcs != null && coreDmcs.length > 0) {
+            for (ICoreDMContext core : coreDmcs) {
+                ILoadInfo coreLoadInfo = getCoreLoadInfo(core);
+                assert (coreLoadInfo instanceof GDBLoadInfo);
+                loadInfo += ((GDBLoadInfo) coreLoadInfo).getILoad();
+            }
+
+            // Take average load of all cores
+            loadInfo = loadInfo / coreDmcs.length;
+        }
+
+        System.out.println("CPU load: " + loadInfo); //$NON-NLS-1$
+
+        return new GDBLoadInfo(loadInfo);
+    }
+
 }

--- a/org.eclipse.tracecompass.dsf.core/src/org/eclipse/tracecompass/internal/dsf/core/service/TraceHardwareAndOSService.java
+++ b/org.eclipse.tracecompass.dsf.core/src/org/eclipse/tracecompass/internal/dsf/core/service/TraceHardwareAndOSService.java
@@ -29,10 +29,16 @@ import org.eclipse.cdt.dsf.service.DsfSession;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.tracecompass.internal.dsf.core.DsfTraceCorePlugin;
+import org.eclipse.tracecompass.lttng2.kernel.core.analysis.cpuusage.LttngKernelCpuUsageAnalysis;
+import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
+import org.eclipse.tracecompass.tmf.core.trace.TmfTraceUtils;
 import org.osgi.framework.BundleContext;
 
 /** */
 public class TraceHardwareAndOSService extends AbstractDsfService implements IGDBHardwareAndOS2, ICachingService {
+
+    final private ITmfTrace fTrace;
+    final private LttngKernelCpuUsageAnalysis fCPUModule;
 
 	@Immutable
 	private static class GDBCPUDMC extends AbstractDMContext
@@ -146,9 +152,19 @@ public class TraceHardwareAndOSService extends AbstractDsfService implements IGD
 
     /**
      * @param session The DSF session for this service.
+     * @param trace The trace associated to this service
      */
-    public TraceHardwareAndOSService(DsfSession session) {
+    public TraceHardwareAndOSService(DsfSession session, ITmfTrace trace) {
     	super(session);
+    	fTrace = trace;
+
+    	//initialize cpu data source
+        fCPUModule = TmfTraceUtils.getAnalysisModuleOfClass(fTrace, LttngKernelCpuUsageAnalysis.class, LttngKernelCpuUsageAnalysis.ID);
+        if (fCPUModule == null) {
+            return;
+        }
+        fCPUModule.schedule();
+        fCPUModule.waitForInitialization();
     }
 
     /**

--- a/org.eclipse.tracecompass.dsf.ui/src/org/eclipse/tracecompass/internal/dsf/ui/DsfTraceUIPlugin.java
+++ b/org.eclipse.tracecompass.dsf.ui/src/org/eclipse/tracecompass/internal/dsf/ui/DsfTraceUIPlugin.java
@@ -11,6 +11,7 @@
 package org.eclipse.tracecompass.internal.dsf.ui;
 
 import org.eclipse.core.runtime.IStatus;
+import org.eclipse.tracecompass.internal.dsf.core.DsfTraceSessionManager;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.BundleContext;
 
@@ -26,6 +27,7 @@ public class DsfTraceUIPlugin extends AbstractUIPlugin {
 
     private static BundleContext fgBundleContext;
 
+    private DsfTraceSessionManager traceManager;
 
 	/**
 	 * The constructor
@@ -42,6 +44,7 @@ public class DsfTraceUIPlugin extends AbstractUIPlugin {
     public void start(BundleContext context) throws Exception {
         fgBundleContext = context;
 		super.start(context);
+        traceManager = new DsfTraceSessionManager();
 	}
 
 	/*
@@ -53,6 +56,7 @@ public class DsfTraceUIPlugin extends AbstractUIPlugin {
 		plugin = null;
         fgBundleContext = null;
 		super.stop(context);
+        traceManager.dispose();
 	}
 
 	/**

--- a/org.eclipse.tracecompass.lttng2.kernel.core/src/org/eclipse/tracecompass/lttng2/kernel/core/analysis/cpuusage/LttngKernelCpuUsageAnalysis.java
+++ b/org.eclipse.tracecompass.lttng2.kernel.core/src/org/eclipse/tracecompass/lttng2/kernel/core/analysis/cpuusage/LttngKernelCpuUsageAnalysis.java
@@ -241,6 +241,168 @@ public class LttngKernelCpuUsageAnalysis extends TmfStateSystemAnalysisModule {
         return map;
     }
 
+    /**
+     * Get a map of time spent on the given CPU by various threads during a time range.
+     *
+     * @param start
+     *            Start time of requested range
+     * @param end
+     *            End time of requested range
+     * @return A map of TID -> time spent on the given CPU in the [start, end] interval
+     */
+    public Map<String, Long> getCpuUsageInRange(Integer[] dCpuNode, long start, long end) {
+        Map<String, Long> map = new HashMap<>();
+        Map<String, Long> totalMap = new HashMap<>();
+
+        ITmfTrace trace = getTrace();
+        ITmfStateSystem cpuSs = getStateSystem();
+        if (trace == null || cpuSs == null) {
+            return map;
+        }
+
+        try {
+            int cpusNode = cpuSs.getQuarkAbsolute(Attributes.CPUS);
+            List<Integer> cpuNodes = cpuSs.getSubAttributes(cpusNode, false);
+
+            if (!validNodes(dCpuNode, cpuNodes)) {
+                Activator.getDefault().logError("Error getting CPU usage, at least one of the requested cpu's is invalid", null); //$NON-NLS-1$
+                return map;
+            }
+
+            ITmfStateSystem kernelSs = TmfStateSystemAnalysisModule.getStateSystem(trace, LttngKernelAnalysis.ID);
+            if (kernelSs == null) {
+                return map;
+            }
+
+            /*
+             * Make sure the start/end times are within the state history, so we
+             * don't get TimeRange exceptions.
+             */
+            long startTime = Math.max(start, cpuSs.getStartTime());
+            startTime = Math.max(startTime, kernelSs.getStartTime());
+            long endTime = Math.min(end, cpuSs.getCurrentEndTime());
+            endTime = Math.min(endTime, kernelSs.getCurrentEndTime());
+            long totalTime = 0;
+            if (endTime < startTime) {
+                return map;
+            }
+
+            /* Get the list of quarks for each CPU and CPU's TIDs */
+            Map<Integer, List<Integer>> tidsPerCpu = new HashMap<>();
+            for (int cpuNode : dCpuNode) {
+                tidsPerCpu.put(cpuNode, cpuSs.getSubAttributes(cpuNode, false));
+            }
+
+            /* Query full states at start and end times */
+            List<ITmfStateInterval> kernelEndState = kernelSs.queryFullState(endTime);
+            List<ITmfStateInterval> endState = cpuSs.queryFullState(endTime);
+            List<ITmfStateInterval> kernelStartState = kernelSs.queryFullState(startTime);
+            List<ITmfStateInterval> startState = cpuSs.queryFullState(startTime);
+
+            long countAtStart, countAtEnd;
+
+            for (Entry<Integer, List<Integer>> entry : tidsPerCpu.entrySet()) {
+                int cpuNode = entry.getKey();
+                List<Integer> tidNodes = entry.getValue();
+
+                String curCpuName = cpuSs.getAttributeName(cpuNode);
+                long cpuTotal = 0;
+
+                /* Get the quark of the thread running on this CPU */
+                int currentThreadQuark = kernelSs.getQuarkAbsolute(Attributes.CPUS, curCpuName, Attributes.CURRENT_THREAD);
+                /* Get the currently running thread on this CPU */
+                int startThread = kernelStartState.get(currentThreadQuark).getStateValue().unboxInt();
+                int endThread = kernelEndState.get(currentThreadQuark).getStateValue().unboxInt();
+
+                for (int tidNode : tidNodes) {
+                    String curTidName = cpuSs.getAttributeName(tidNode);
+                    int tid = Integer.parseInt(curTidName);
+
+                    countAtEnd = endState.get(tidNode).getStateValue().unboxLong();
+                    countAtStart = startState.get(tidNode).getStateValue().unboxLong();
+                    if (countAtStart == -1) {
+                        countAtStart = 0;
+                    }
+                    if (countAtEnd == -1) {
+                        countAtEnd = 0;
+                    }
+
+                    /*
+                     * Interpolate start and end time of threads running at
+                     * those times
+                     */
+                    if (tid == startThread || startThread == -1) {
+                        long runningTime = kernelStartState.get(currentThreadQuark).getEndTime() - kernelStartState.get(currentThreadQuark).getStartTime();
+                        long runningEnd = kernelStartState.get(currentThreadQuark).getEndTime();
+
+                        countAtStart = interpolateCount(countAtStart, startTime, runningEnd, runningTime);
+                    }
+                    if (tid == endThread) {
+                        long runningTime = kernelEndState.get(currentThreadQuark).getEndTime() - kernelEndState.get(currentThreadQuark).getStartTime();
+                        long runningEnd = kernelEndState.get(currentThreadQuark).getEndTime();
+
+                        countAtEnd = interpolateCount(countAtEnd, endTime, runningEnd, runningTime);
+                    }
+                    /*
+                     * If startThread is -1, we made the hypothesis that the
+                     * process running at start was the current one. If the
+                     * count is negative, we were wrong in this hypothesis. Also
+                     * if the time at end is 0, it either means the process
+                     * hasn't been on the CPU or that we still don't know who is
+                     * running. In both cases, that invalidates the hypothesis.
+                     */
+                    if ((startThread == -1) && ((countAtEnd - countAtStart < 0) || (countAtEnd == 0))) {
+                        countAtStart = 0;
+                    }
+
+                    long currentCount = countAtEnd - countAtStart;
+                    if (currentCount < 0) {
+                        Activator.getDefault().logWarning(String.format("Negative count: start %d, end %d", countAtStart, countAtEnd)); //$NON-NLS-1$
+                        currentCount = 0;
+                    } else if (currentCount > endTime - startTime) {
+                        Activator.getDefault().logWarning(String.format("CPU Usage: Spent more time on CPU than allowed: %s spent %d when max should be %d", curTidName, currentCount, endTime - startTime)); //$NON-NLS-1$
+                        currentCount = 0;
+                    }
+                    cpuTotal += currentCount;
+                    map.put(curCpuName + SPLIT_STRING + curTidName, currentCount);
+                    addToMap(totalMap, curTidName, currentCount);
+                    totalTime += (currentCount);
+                }
+                map.put(curCpuName, cpuTotal);
+            }
+
+            /* Add the totals to the map */
+            for (Entry<String, Long> entry : totalMap.entrySet()) {
+                map.put(TOTAL + SPLIT_STRING + entry.getKey(), entry.getValue());
+            }
+            map.put(TOTAL, totalTime);
+
+        } catch (TimeRangeException | AttributeNotFoundException e) {
+            /*
+             * Assume there is no events or the attribute does not exist yet,
+             * nothing will be put in the map.
+             */
+        } catch (StateValueTypeException | StateSystemDisposedException e) {
+            /*
+             * These other exception types would show a logic problem, so they
+             * should not happen.
+             */
+            Activator.getDefault().logError("Error getting CPU usage in a time range", e); //$NON-NLS-1$
+        }
+
+        return map;
+    }
+
+    private static boolean validNodes(Integer[] nodesSubset, List<Integer> nodes) {
+        // Validate that all nodes in the subset are contained in the full list of nodes
+        for (Integer node : nodesSubset) {
+            if (!nodes.contains(node)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     private static long interpolateCount(long count, long ts, long runningEnd, long runningTime) {
         long newCount = count;
 

--- a/org.eclipse.tracecompass.target/tracecompass-cdt-e4.4.target
+++ b/org.eclipse.tracecompass.target/tracecompass-cdt-e4.4.target
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?><target name="tracecompass-cdt-e4.4" sequenceNumber="1">
+<locations>
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.swtbot.eclipse.feature.group" version="0.0.0"/>
+<unit id="org.eclipse.swtbot.feature.group" version="0.0.0"/>
+<unit id="org.eclipse.swtbot.eclipse.test.junit.feature.group" version="0.0.0"/>
+<repository location="http://download.eclipse.org/technology/swtbot/releases/latest"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.cdt.gnu.dsf.feature.group" version="0.0.0"/>
+<repository location="http://download.eclipse.org/tools/cdt/releases/8.5"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.test.feature.group" version="0.0.0"/>
+<unit id="org.eclipse.platform.ide" version="0.0.0"/>
+<unit id="org.eclipse.equinox.executable.feature.group" version="0.0.0"/>
+<unit id="org.eclipse.jdt.annotation" version="1.1.0.v20140129-1625"/>
+<unit id="org.eclipse.pde.runtime" version="0.0.0"/>
+<repository location="http://download.eclipse.org/eclipse/updates/4.4/"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.apache.log4j" version="0.0.0"/>
+<unit id="org.apache.log4j.source" version="0.0.0"/>
+<unit id="net.sourceforge.lpg.lpgjavaruntime" version="0.0.0"/>
+<unit id="org.junit" version="0.0.0"/>
+<unit id="org.junit.source" version="0.0.0"/>
+<unit id="org.mockito" version="0.0.0"/>
+<unit id="org.hamcrest.core" version="0.0.0"/>
+<unit id="org.antlr.runtime" version="3.2.0.v201101311130"/>
+<unit id="org.antlr.runtime.source" version="3.2.0.v201101311130"/>
+<unit id="org.swtchart" version="0.0.0"/>
+<unit id="com.google.guava" version="15.0.0.v201403281430"/>
+<unit id="org.apache.derby" version="0.0.0"/>
+<unit id="org.json" version="0.0.0"/>
+<repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20140525021250/repository/"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.license.feature.group" version="0.0.0"/>
+<repository location="http://download.eclipse.org/cbi/updates/license"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.mylyn.wikitext_feature.feature.group" version="0.0.0"/>
+<repository location="http://download.eclipse.org/mylyn/releases/3.12/"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.remote.feature.group" version="0.0.0"/>
+<repository location="http://download.eclipse.org/tools/ptp/updates/luna"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.jetty.bundles.f.feature.group" version="0.0.0"/>
+<repository location="http://download.eclipse.org/jetty/updates/jetty-bundles-8.x"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.rse.feature.group" version="0.0.0"/>
+<repository location="http://download.eclipse.org/tm/updates/3.6milestones/"/>
+</location>
+</locations>
+<targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+<launcherArgs>
+<vmArgs>-Xms40m
+-Xmx512M
+-XX:MaxPermSize=256m</vmArgs>
+<programArgs>-consolelog</programArgs>
+</launcherArgs>
+</target>

--- a/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/tmf/ui/project/model/TmfOpenTraceHelper.java
+++ b/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/tmf/ui/project/model/TmfOpenTraceHelper.java
@@ -369,7 +369,7 @@ public class TmfOpenTraceHelper {
                 final String editorId = (traceEditorId != null) ? traceEditorId : TmfEventsEditor.ID;
                 final IEditorInput editorInput = new TmfEditorInput(file, trace);
 
-                DsfTraceSessionManager.startDsfSession();
+                DsfTraceSessionManager.startDsfSession(trace);
 
                 Display.getDefault().asyncExec(new Runnable() {
                     @Override

--- a/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/tmf/ui/project/model/TmfOpenTraceHelper.java
+++ b/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/tmf/ui/project/model/TmfOpenTraceHelper.java
@@ -32,7 +32,6 @@ import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.MessageBox;
 import org.eclipse.swt.widgets.Shell;
-import org.eclipse.tracecompass.internal.dsf.core.DsfTraceSessionManager;
 import org.eclipse.tracecompass.internal.tmf.ui.Activator;
 import org.eclipse.tracecompass.internal.tmf.ui.project.model.TmfImportHelper;
 import org.eclipse.tracecompass.tmf.core.TmfCommonConstants;
@@ -368,8 +367,6 @@ public class TmfOpenTraceHelper {
                 String traceEditorId = traceElement.getEditorId();
                 final String editorId = (traceEditorId != null) ? traceEditorId : TmfEventsEditor.ID;
                 final IEditorInput editorInput = new TmfEditorInput(file, trace);
-
-                DsfTraceSessionManager.startDsfSession(trace);
 
                 Display.getDefault().asyncExec(new Runnable() {
                     @Override


### PR DESCRIPTION
The following changes allow you to:

1) Compile your CDT and Trace-compass plugins the same workspace, using the .target file
2) The proof of concept can be exercised by
      a) opening a kernel trace with trace-compass
      b) open the "visualizer" view
      c) from the visualizer you should see 1cpu, 2 cores 
      d) from the visualizer context menu, Enable load monitor
      c) The load meters should now reflect the cpu load for the duration of the trace

I think it's good enough for a proof of concept.

Next, 
- Visualize load on the time selected by user over the trace views
- Discuss and improve API
- Proper closing 
- etc..
