### PR TITLE
Add function to resolve active thread + bug fixes

### DIFF
--- a/org.eclipse.tracecompass.dsf.core/src/org/eclipse/tracecompass/internal/dsf/core/DsfTraceSessionManager.java
+++ b/org.eclipse.tracecompass.dsf.core/src/org/eclipse/tracecompass/internal/dsf/core/DsfTraceSessionManager.java
@@ -71,7 +71,7 @@ public class DsfTraceSessionManager {
      * @param trace - Remove the session associated to the given trace
      */
     public static void endSession(ITmfTrace trace) {
-        DsfSession session =  fTraceToSessionMap.get(trace);
+        DsfSession session =  fTraceToSessionMap.remove(trace);
         // Check if the session is still tracked / active
         if (session == null) {
             return;
@@ -92,8 +92,6 @@ public class DsfTraceSessionManager {
         }
 
         DsfSession.endSession(session);
-        // stop tracing this session
-        fTraceToSessionMap.remove(trace);
     }
 
 

--- a/org.eclipse.tracecompass.dsf.core/src/org/eclipse/tracecompass/internal/dsf/core/service/AbstractDsfTraceService.java
+++ b/org.eclipse.tracecompass.dsf.core/src/org/eclipse/tracecompass/internal/dsf/core/service/AbstractDsfTraceService.java
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Ericsson.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Alvaro Sanchez-Leon (Ericsson) - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tracecompass.internal.dsf.core.service;
+
+import org.eclipse.cdt.dsf.concurrent.ImmediateExecutor;
+import org.eclipse.cdt.dsf.concurrent.RequestMonitor;
+import org.eclipse.cdt.dsf.service.AbstractDsfService;
+import org.eclipse.cdt.dsf.service.DsfServicesTracker;
+import org.eclipse.cdt.dsf.service.DsfSession;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.tracecompass.internal.dsf.core.DsfTraceCorePlugin;
+import org.osgi.framework.BundleContext;
+
+
+/**
+ * Common and abstract methods to all DSF Trace Services
+ *
+ */
+public abstract class AbstractDsfTraceService extends AbstractDsfService {
+    final protected IDsfTraceModelService fModelService;
+
+    /**
+     * @param session - Debug session
+     * @throws CoreException - Exception notification at the construction of this instance
+     */
+    public AbstractDsfTraceService(@NonNull DsfSession session) throws CoreException {
+        super(session);
+        DsfServicesTracker tracker = new DsfServicesTracker(DsfTraceCorePlugin.getBundleContext(), session.getId());
+        fModelService = tracker.getService(IDsfTraceModelService.class);
+        tracker.dispose();
+        if (fModelService == null) {
+            throw new CoreException(new Status(IStatus.ERROR, DsfTraceCorePlugin.PLUGIN_ID, REQUEST_FAILED, "Unable to resolve the Trace Model Service", null)); //$NON-NLS-1$
+        }
+    }
+
+    /**
+     * This method initializes this service.
+     *
+     * @param requestMonitor
+     *            The request monitor indicating the operation is finished
+     */
+    @Override
+    public void initialize(final RequestMonitor requestMonitor) {
+        super.initialize(new RequestMonitor(ImmediateExecutor.getInstance(), requestMonitor) {
+            @Override
+            protected void handleSuccess() {
+                doInitialize(requestMonitor);
+            }
+        });
+    }
+
+    /**
+     * Service initialization e.g. Registration to a debug session
+     * @param requestMonitor - asynchronous call back request monitor
+     */
+    protected abstract void doInitialize(RequestMonitor requestMonitor);
+
+
+    @Override
+    public void shutdown(RequestMonitor requestMonitor) {
+        unregister();
+        super.shutdown(requestMonitor);
+    }
+
+    @Override
+    protected BundleContext getBundleContext() {
+        return DsfTraceCorePlugin.getBundleContext();
+    }
+
+}

--- a/org.eclipse.tracecompass.dsf.core/src/org/eclipse/tracecompass/internal/dsf/core/service/DsfTraceModelService.java
+++ b/org.eclipse.tracecompass.dsf.core/src/org/eclipse/tracecompass/internal/dsf/core/service/DsfTraceModelService.java
@@ -1,0 +1,701 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Ericsson.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Alvaro Sanchez-Leon (Ericsson) - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tracecompass.internal.dsf.core.service;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.cdt.dsf.concurrent.ImmediateExecutor;
+import org.eclipse.cdt.dsf.concurrent.Immutable;
+import org.eclipse.cdt.dsf.concurrent.RequestMonitor;
+import org.eclipse.cdt.dsf.datamodel.AbstractDMContext;
+import org.eclipse.cdt.dsf.datamodel.DMContexts;
+import org.eclipse.cdt.dsf.datamodel.IDMContext;
+import org.eclipse.cdt.dsf.debug.service.IProcesses.IThreadDMContext;
+import org.eclipse.cdt.dsf.debug.service.IProcesses.IThreadDMData;
+import org.eclipse.cdt.dsf.debug.service.IRunControl.IContainerDMContext;
+import org.eclipse.cdt.dsf.debug.service.IRunControl.IExecutionDMContext;
+import org.eclipse.cdt.dsf.debug.service.IRunControl.IExecutionDMData;
+import org.eclipse.cdt.dsf.debug.service.IRunControl.StateChangeReason;
+import org.eclipse.cdt.dsf.debug.service.command.ICommandControlService;
+import org.eclipse.cdt.dsf.debug.service.command.ICommandControlService.ICommandControlDMContext;
+import org.eclipse.cdt.dsf.gdb.service.IGDBHardwareAndOS.ICPUDMContext;
+import org.eclipse.cdt.dsf.gdb.service.IGDBHardwareAndOS.ICoreDMContext;
+import org.eclipse.cdt.dsf.gdb.service.IGDBHardwareAndOS.IHardwareTargetDMContext;
+import org.eclipse.cdt.dsf.gdb.service.IGDBHardwareAndOS2.ILoadInfo;
+import org.eclipse.cdt.dsf.gdb.service.IGDBProcesses.IGdbThreadDMData;
+import org.eclipse.cdt.dsf.mi.service.IMIExecutionDMContext;
+import org.eclipse.cdt.dsf.mi.service.IMIProcessDMContext;
+import org.eclipse.cdt.dsf.service.AbstractDsfService;
+import org.eclipse.cdt.dsf.service.DsfServicesTracker;
+import org.eclipse.cdt.dsf.service.DsfSession;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.tracecompass.analysis.os.linux.core.cpuusage.KernelCpuUsageAnalysis;
+import org.eclipse.tracecompass.analysis.os.linux.core.kernelanalysis.Attributes;
+import org.eclipse.tracecompass.analysis.os.linux.core.kernelanalysis.KernelAnalysis;
+import org.eclipse.tracecompass.internal.dsf.core.DsfTraceCorePlugin;
+import org.eclipse.tracecompass.statesystem.core.ITmfStateSystem;
+import org.eclipse.tracecompass.statesystem.core.exceptions.AttributeNotFoundException;
+import org.eclipse.tracecompass.statesystem.core.exceptions.StateSystemDisposedException;
+import org.eclipse.tracecompass.statesystem.core.exceptions.StateValueTypeException;
+import org.eclipse.tracecompass.statesystem.core.exceptions.TimeRangeException;
+import org.eclipse.tracecompass.statesystem.core.interval.ITmfStateInterval;
+import org.eclipse.tracecompass.statesystem.core.statevalue.ITmfStateValue;
+import org.eclipse.tracecompass.tmf.core.signal.TmfRangeSynchSignal;
+import org.eclipse.tracecompass.tmf.core.signal.TmfSignalHandler;
+import org.eclipse.tracecompass.tmf.core.signal.TmfSignalManager;
+import org.eclipse.tracecompass.tmf.core.signal.TmfTimeSynchSignal;
+import org.eclipse.tracecompass.tmf.core.statesystem.TmfStateSystemAnalysisModule;
+import org.eclipse.tracecompass.tmf.core.timestamp.TmfTimeRange;
+import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
+import org.eclipse.tracecompass.tmf.core.trace.TmfTraceUtils;
+import org.osgi.framework.BundleContext;
+
+/** */
+public class DsfTraceModelService extends AbstractDsfService implements IDsfTraceModelService {
+
+    final private ITmfTrace fTrace;
+    final private KernelCpuUsageAnalysis fCPUModule;
+    final private ITmfStateSystem fStateSys;
+    final private Map<ICPUDMContext, ICoreDMContext[]> fMapCPUToCores = new HashMap<>();
+    private long fStartTime;
+    private long fEndTime;
+    private ICommandControlDMContext fCommandControlContext;
+    private Map<ICoreDMContext, TraceExecutionDMC> fMapCoreToExecution = new HashMap<>();
+
+    @Immutable
+    private class GDBCPUDMC extends AbstractDMContext implements ICPUDMContext
+    {
+        /**
+         * String ID that is used to identify the thread in the GDB/MI protocol.
+         */
+        private final String fId;
+
+        /**
+         * @param sessionId
+         *            The session
+         * @param targetDmc
+         *            The target
+         * @param id
+         *            the CPU id
+         */
+        protected GDBCPUDMC(String sessionId, IHardwareTargetDMContext targetDmc, String id) {
+            super(sessionId, targetDmc == null ? new IDMContext[] { fCommandControlContext } : new IDMContext[] { fCommandControlContext, targetDmc });
+            fId = id;
+        }
+
+        @Override
+        public String getId() {
+            return fId;
+        }
+
+        @Override
+        public String toString() {
+            return baseToString() + ".CPU[" + fId + "]";} //$NON-NLS-1$ //$NON-NLS-2$
+
+        @Override
+        public boolean equals(Object obj) {
+            return baseEquals(obj) && ((GDBCPUDMC) obj).fId.equals(fId);
+        }
+
+        @Override
+        public int hashCode() {
+            return baseHashCode() ^ fId.hashCode();
+        }
+    }
+
+    @Immutable
+    private static class GDBCoreDMC extends AbstractDMContext
+            implements ICoreDMContext
+    {
+        /**
+         * E.g. The name given to the State system node representing a cpu core
+         */
+        private final String fId;
+        /**
+         * The node in the Tmftrace State system,
+         */
+        private final Integer fNode;
+
+        public GDBCoreDMC(String sessionId, ICPUDMContext CPUDmc, Integer coreNode, String id) {
+            super(sessionId, CPUDmc == null ? new IDMContext[0] : new IDMContext[] { CPUDmc });
+            fId = id;
+            fNode = coreNode;
+        }
+
+        @Override
+        public String getId() {
+            return fId;
+        }
+
+        // The State system node is the key to access any additional
+        // information, however the value does not represent the actual core id
+        public Integer getNode() {
+            return fNode;
+        }
+
+        @Override
+        public String toString() {
+            return baseToString() + ".core[" + fId + "]";} //$NON-NLS-1$ //$NON-NLS-2$
+
+        @Override
+        public boolean equals(Object obj) {
+            return baseEquals(obj) &&
+                    (((GDBCoreDMC) obj).fId == null ? fId == null : ((GDBCoreDMC) obj).fId.equals(fId));
+        }
+
+        @Override
+        public int hashCode() {
+            return baseHashCode() ^ (fId == null ? 0 : fId.hashCode());
+        }
+    }
+
+    private static class TraceExecutionDMC extends AbstractDMContext implements IContainerDMContext, IMIProcessDMContext, IMIExecutionDMContext {
+        IThreadDMData fThreadData;
+
+        public TraceExecutionDMC(DsfSession session, GDBCoreDMC parent, IThreadDMData threadData) {
+            super(session, new IDMContext[] { parent });
+            fThreadData = threadData;
+        }
+
+        public IThreadDMData getExecutionData() {
+            return fThreadData;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            return baseEquals(obj);
+        }
+
+        @Override
+        public int hashCode() {
+            return baseHashCode();
+        }
+
+        @Override
+        public int getThreadId() {
+            return Integer.valueOf(fThreadData.getId());
+        }
+
+        @Override
+        public String getProcId() {
+            // TODO: Resolve process id
+            return "0"; //$NON-NLS-1$
+        }
+    }
+
+    @Immutable
+    private class GDBLoadInfo implements ILoadInfo {
+        private int fILoad;
+        private String fLoad;
+        private Map<String, String> fDetailedLoad;
+
+        public GDBLoadInfo(String load, Map<String, String> detailedLoad) {
+            fLoad = load;
+            fILoad = Integer.valueOf(load);
+            fDetailedLoad = detailedLoad;
+        }
+
+        public GDBLoadInfo(int load) {
+            this(String.valueOf(load), null);
+            fILoad = load;
+        }
+
+        public int getILoad() {
+            return fILoad;
+        }
+
+        @Override
+        public String getLoad() {
+            return fLoad;
+        }
+
+        @Override
+        public Map<String, String> getDetailedLoad() {
+            return fDetailedLoad;
+        }
+    }
+
+    @Immutable
+    private static class TraceThreadDMData implements IGdbThreadDMData {
+        private int fThreadId;
+        private String fExecutableName;
+        private String fCoreId;
+
+        TraceThreadDMData(int threadId, String executableName, String coreId) {
+            fThreadId = threadId;
+            fExecutableName = executableName;
+            fCoreId = coreId;
+        }
+
+        @Override
+        public String getName() {
+            return fExecutableName;
+        }
+
+        @Override
+        public String getId() {
+            return String.valueOf(fThreadId);
+        }
+
+        @Override
+        public boolean isDebuggerAttached() {
+            return false;
+        }
+
+        @Override
+        public String[] getCores() {
+            return new String[] { fCoreId };
+        }
+
+        @Override
+        public String getOwner() {
+            // TODO resolve owner
+            return "Owner ?"; //$NON-NLS-1$
+        }
+    }
+
+    /**
+     * @param session
+     *            The DSF session for this service.
+     * @param trace
+     *            The trace associated to this service
+     * @throws CoreException
+     *             -
+     */
+    public DsfTraceModelService(@NonNull DsfSession session, @NonNull ITmfTrace trace) throws CoreException {
+        super(session);
+
+        // Use VIP to make sure the time selection is first updated in this
+        // service i.e. before the UI queries for the load
+        TmfSignalManager.registerVIP(this);
+
+        fTrace = trace;
+
+        // initialize cpu data source
+        fCPUModule = TmfTraceUtils.getAnalysisModuleOfClass(fTrace, KernelCpuUsageAnalysis.class, KernelCpuUsageAnalysis.ID);
+        if (fCPUModule == null) {
+            // Notify of incorrect initialization
+            throw new CoreException(new Status(IStatus.ERROR, DsfTraceCorePlugin.PLUGIN_ID, INVALID_HANDLE, "Unable to resolve the CPU Usage Analysis module from trace: " + trace, null)); //$NON-NLS-1$
+        }
+
+        fCPUModule.schedule();
+        fCPUModule.waitForInitialization();
+        fStateSys = fCPUModule.getStateSystem();
+        if (fStateSys == null) {
+            // Notify of incorrect initialization
+            throw new CoreException(new Status(IStatus.ERROR, DsfTraceCorePlugin.PLUGIN_ID, INVALID_HANDLE, "Unable to resolve the State System from trace: " + trace, null)); //$NON-NLS-1$
+        }
+
+        fStartTime = fStateSys.getStartTime();
+        fEndTime = fStateSys.getCurrentEndTime();
+
+        // Resolve the root context from the command control service
+        DsfServicesTracker tracker = new DsfServicesTracker(DsfTraceCorePlugin.getBundleContext(), session.getId());
+        ICommandControlService controlService = tracker.getService(ICommandControlService.class);
+        tracker.dispose();
+        if (controlService == null || controlService.getContext() == null) {
+            throw new CoreException(new Status(IStatus.ERROR, DsfTraceCorePlugin.PLUGIN_ID, REQUEST_FAILED, "Unable to resolve the ICommandControlService: " + trace, null)); //$NON-NLS-1$
+        }
+
+        fCommandControlContext = controlService.getContext();
+    }
+
+    /**
+     * This method initializes this service.
+     *
+     * @param requestMonitor
+     *            The request monitor indicating the operation is finished
+     */
+    @Override
+    public void initialize(final RequestMonitor requestMonitor) {
+        super.initialize(new RequestMonitor(ImmediateExecutor.getInstance(), requestMonitor) {
+            @Override
+            protected void handleSuccess() {
+                doInitialize(requestMonitor);
+            }
+        });
+    }
+
+    /**
+     * This method initializes this service after our superclass's initialize()
+     * method succeeds.
+     *
+     * @param requestMonitor
+     *            The call-back object to notify when this service's
+     *            initialization is done.
+     */
+    private void doInitialize(RequestMonitor requestMonitor) {
+        // Register this service.
+        register(new String[] { IDsfTraceModelService.class.getName(),
+                DsfTraceModelService.class.getName() },
+                new Hashtable<String, String>());
+
+        requestMonitor.done();
+    }
+
+    @Override
+    public void shutdown(RequestMonitor requestMonitor) {
+        TmfSignalManager.deregister(this);
+        unregister();
+        reset();
+        super.shutdown(requestMonitor);
+    }
+
+    /**
+     * Resolve the time interval to use for the calculation of load
+     *
+     * @param signal
+     *            -
+     */
+    @TmfSignalHandler
+    public void timeSelected(TmfTimeSynchSignal signal) {
+        // Broadcasted in nano seconds
+        long beginTime = signal.getBeginTime().getValue();
+        long endTime = signal.getEndTime().getValue();
+        fEndTime = endTime;
+        if (beginTime == endTime) {
+            // calculate load period over previous 1/2000 of the trace's time
+            // range
+            long delta = (fStateSys.getCurrentEndTime() - fStateSys.getStartTime()) / 2000;
+            fStartTime = fEndTime - delta;
+        } else {
+            fStartTime = beginTime;
+        }
+
+        assert fEndTime > fStartTime;
+        System.out.println("Current end time: " + fStateSys.getCurrentEndTime());
+        System.out.println("Time Selected: " + fStartTime + "->" + fEndTime + ": " + (fEndTime - fStartTime));
+
+        reset();
+    }
+
+    // initialize model, ready to be refresh upon a query
+    private void reset() {
+        fMapCPUToCores.clear();
+        fMapCoreToExecution.clear();
+    }
+
+    /**
+     * @param signal -
+     */
+    @TmfSignalHandler
+    public void timeRangeSelected(TmfRangeSynchSignal signal) {
+        // Broadcasted in nano seconds
+        TmfTimeRange timeRange = signal.getCurrentRange();
+        fStartTime = timeRange.getStartTime().getValue();
+        fEndTime = timeRange.getStartTime().getValue();
+        System.out.println("Time Range selected: " + fStartTime + "->" + fEndTime);
+        reset();
+    }
+
+    /**
+     * @return The bundle context of the plug-in to which this service belongs.
+     */
+    @Override
+    protected BundleContext getBundleContext() {
+        return DsfTraceCorePlugin.getBundleContext();
+    }
+
+    /**
+     * Return the CPU context resolved for the associated trace
+     *
+     * @param dmc - parent context
+     * @return - All resolved CPUs in the associated trace
+     */
+    @Override
+    public ICPUDMContext[] getCPUs(final IHardwareTargetDMContext dmc) {
+        if (fMapCPUToCores.keySet().size() > 0) {
+            // CPU's already resolved for the associated trace
+            ICPUDMContext[] cpus = fMapCPUToCores.keySet().toArray(new ICPUDMContext[fMapCPUToCores.size()]);
+            System.out.println("getCPUs, returning cpus from map: " + cpus.length);
+            return cpus;
+        }
+
+        return resolveCPUContexts(dmc);
+    }
+
+    @Override
+    public ICoreDMContext[] getCores(IDMContext dmc) {
+        ICPUDMContext cpuDmc = DMContexts.getAncestorOfType(dmc, ICPUDMContext.class);
+
+        if (cpuDmc == null) {
+            // Retrieve all available cores
+            Set<ICPUDMContext> cpus = fMapCPUToCores.keySet();
+            if (cpus.size() < 1) {
+                // Most likely not yet initialized, try to resolve the CPUs
+                resolveCPUContexts(null);
+            }
+
+            // Now retrieve all available cores
+            return getAllCores();
+        }
+
+        // Check if the ICoreDMContexts exist in our cpu map
+        ICoreDMContext[] coreDmcs = fMapCPUToCores.get(cpuDmc);
+        if (coreDmcs != null) {
+            // We have previously resolved the cores, so lets return them
+            return coreDmcs;
+        }
+
+        // Not available but cpu context is not null, not expected but we can
+        // assume there are no core context on this trace
+        return new ICoreDMContext[0];
+    }
+
+    private ICoreDMContext[] getAllCores() {
+        List<ICoreDMContext> cores = new ArrayList<>();
+        Set<ICPUDMContext> cpus = fMapCPUToCores.keySet();
+        if (cpus.size() > 0) {
+            for (ICPUDMContext cpu : cpus) {
+                ICoreDMContext[] coreDmcs = fMapCPUToCores.get(cpu);
+                if (coreDmcs != null) {
+                    for (ICoreDMContext coreDmc : coreDmcs) {
+                        cores.add(coreDmc);
+                    }
+                } else {
+                    System.out.println("No cores associated to cpu: " + cpu.toString());
+                }
+            }
+        }
+
+        System.out.println("getAllCores, returning " + cores.size() + ", cores");
+        return new ICoreDMContext[cores.size()];
+    }
+
+    @Override
+    public ICPUDMContext createCPUContext(IHardwareTargetDMContext targetDmc, String CPUId) {
+        ICPUDMContext cpuDmc = new GDBCPUDMC(getSession().getId(), targetDmc, CPUId);
+        return cpuDmc;
+    }
+
+    private ICoreDMContext createCoreContext(ICPUDMContext cpuDmc, Integer coreNode, String coreId) {
+        GDBCoreDMC core = new GDBCoreDMC(getSession().getId(), cpuDmc, coreNode, coreId);
+        // Make it possible to resolve the execution context from a core or vice
+        // versa
+        fMapCoreToExecution.put(core, new TraceExecutionDMC(getSession(), core, getActiveThread(core)));
+        return core;
+    }
+
+    /**
+     * Need to resolve the associated CPU's and Cores
+     *
+     * TODO: Trace compass does not seem to divide core and cpu today, For now
+     * lets go with one CORE per CPU, and use the Trace compass CPU's as cores
+     *
+     * @param dmc
+     * @return
+     */
+    private ICPUDMContext[] resolveCPUContexts(IHardwareTargetDMContext dmc) {
+        // For now treat a TRACE-CPU as Core and associate it with a local CPU
+        // context
+        try {
+            int coreSSNode = fStateSys.getQuarkAbsolute(Attributes.CPUS);
+            List<Integer> coreNodes = fStateSys.getSubAttributes(coreSSNode, false);
+
+            // Represent it as one core per CPU
+            ICPUDMContext[] cpuDmcs = new ICPUDMContext[coreNodes.size()];
+            int i = 0;
+            for (Integer coreNode : coreNodes) {
+                String coreName = fStateSys.getAttributeName(coreNode);
+                ICPUDMContext cpuDmc = cpuDmcs[i] = createCPUContext(dmc, String.valueOf(i));
+                ICoreDMContext[] coreDmcs = new ICoreDMContext[] { createCoreContext(cpuDmcs[i], coreNode, coreName) };
+                fMapCPUToCores.put(cpuDmc, coreDmcs);
+                System.out.println("resolved core #" + coreName);
+                i++;
+            }
+
+            // Normal scenario, returning contexts for each CPU
+            System.out.println("resolved " + cpuDmcs.length + " CPUs"); //$NON-NLS-1$ //$NON-NLS-2$
+
+            return cpuDmcs;
+        } catch (AttributeNotFoundException e) {
+            // No core attributes found
+            System.out.println("State system, AttributeNotfound");
+            return new ICPUDMContext[0];
+        }
+    }
+
+    @Override
+    public ILoadInfo getLoadInfo(final IDMContext context) throws CoreException {
+        if (context instanceof ICoreDMContext) {
+            System.out.println("********** CORE **************");
+            return getCoreLoadInfo((ICoreDMContext) context);
+        }
+
+        if (context instanceof ICPUDMContext) {
+            System.out.println("*********** CPU *************");
+            // Resolve the load for given cpu context
+            return getCPULoadInfo((ICPUDMContext) context);
+        }
+
+        // we only support getting the load for a CPU or a core
+        throw new CoreException(new Status(IStatus.ERROR, DsfTraceCorePlugin.PLUGIN_ID, INVALID_HANDLE, "Load information not supported for this context type", null)); //$NON-NLS-1$
+    }
+
+    private IThreadDMData getActiveThread(ICoreDMContext coreDmc) {
+        // Validate context, and provide a handle to the internal class
+        // implementation
+        assert (coreDmc instanceof GDBCoreDMC);
+        String execName = ""; //$NON-NLS-1$
+        int currentThreadId = 0;
+
+        GDBCoreDMC context = (GDBCoreDMC) coreDmc;
+
+        ITmfStateSystem ss = TmfStateSystemAnalysisModule.getStateSystem(fTrace, KernelAnalysis.ID);
+        if (ss != null) {
+
+            try {
+                int cpuQuark = resolveKernelCpuQuark(ss, context.fId);
+                int currentThreadQuark = ss.getQuarkRelative(cpuQuark, Attributes.CURRENT_THREAD);
+                ITmfStateInterval interval = ss.querySingleState(fEndTime, currentThreadQuark);
+                if (!interval.getStateValue().isNull()) {
+                    ITmfStateValue value = interval.getStateValue();
+                    currentThreadId = value.unboxInt();
+
+                    int execNameQuark = ss.getQuarkAbsolute(Attributes.THREADS, Integer.toString(currentThreadId), Attributes.EXEC_NAME);
+                    interval = ss.querySingleState(fEndTime, execNameQuark);
+                    if (!interval.getStateValue().isNull()) {
+                        value = interval.getStateValue();
+                        execName = value.unboxStr();
+                    }
+                }
+
+                System.out.println("Current Thread id: " + currentThreadId + "\nCurrent executable: " + execName); //$NON-NLS-1$
+            } catch (AttributeNotFoundException | TimeRangeException | StateValueTypeException e) {
+                System.out.println("Error resolving active thread"); //$NON-NLS-1$
+                e.printStackTrace();
+            } catch (StateSystemDisposedException e) {
+                /* Ignored */
+            }
+        }
+
+        return new TraceThreadDMData(currentThreadId, execName, coreDmc.getId());
+    }
+
+    private static int resolveKernelCpuQuark(ITmfStateSystem ss, String coreName) throws AttributeNotFoundException {
+        int cpusNode = ss.getQuarkAbsolute(Attributes.CPUS);
+        List<Integer> cpuNodes = ss.getSubAttributes(cpusNode, false);
+
+        // Get the names to match against the name on the cpu state system
+
+        int ssNode = -1;
+        // Resolve the selected cpu node quark on the kernel ss
+        for (int cpuNode : cpuNodes) {
+            String ssCpuName = ss.getAttributeName(cpuNode);
+            if (ssCpuName.equals(coreName)) {
+                ssNode = cpuNode;
+                break;
+            }
+        }
+
+        return ssNode;
+    }
+
+    private ILoadInfo getCoreLoadInfo(ICoreDMContext coreDmc) {
+        long startTime = fStartTime;
+        long endTime = fEndTime;
+
+        double duration = endTime - startTime;
+
+        // validate time ranges and prevent division by zero
+        if (duration < 1) {
+            assert false;
+            throw new TimeRangeException();
+        }
+
+        // Validate context, and provide a handle to the internal class
+        // implementation
+        assert (coreDmc instanceof GDBCoreDMC);
+        GDBCoreDMC context = (GDBCoreDMC) coreDmc;
+
+        Integer[] coreNode = new Integer[] { context.getNode() };
+
+        Map<String, Long> tidToCPUTime = fCPUModule.getCpuUsageInRange(coreNode, startTime, endTime);
+
+        // The map from thread to time spent includes a grand total identified
+        // with the key "total"
+        double totCpuTime = tidToCPUTime.get("total"); //$NON-NLS-1$
+        String cpuName = fStateSys.getAttributeName(context.getNode());
+        // The idle time is represented by a thread id of zero over the
+        // following key=value format "cpuname/threadId=value"
+        double idleCpuTime = tidToCPUTime.get(cpuName + "/0"); //$NON-NLS-1$
+        totCpuTime = totCpuTime - idleCpuTime;
+
+        double loadPercent = (totCpuTime / duration) * 100;
+        System.out.println("Core " + context.getId() + ", load: " + (int) loadPercent);
+
+        return new GDBLoadInfo((int) loadPercent);
+    }
+
+    private ILoadInfo getCPULoadInfo(ICPUDMContext cpuDmc) {
+        int loadInfo = 0;
+
+        // Resolve the context for the cores
+        ICoreDMContext[] coreDmcs = fMapCPUToCores.get(cpuDmc);
+
+        if (coreDmcs != null && coreDmcs.length > 0) {
+            for (ICoreDMContext core : coreDmcs) {
+                ILoadInfo coreLoadInfo = getCoreLoadInfo(core);
+                assert (coreLoadInfo instanceof GDBLoadInfo);
+                loadInfo += ((GDBLoadInfo) coreLoadInfo).getILoad();
+            }
+
+            // Take average load of all cores
+            loadInfo = loadInfo / coreDmcs.length;
+        }
+
+        System.out.println("CPU load: " + cpuDmc.getId() + "->" + loadInfo + "\n"); //$NON-NLS-1$
+
+        return new GDBLoadInfo(loadInfo);
+    }
+
+    // Processes related API
+    @Override
+    public IDMContext[] getProcessesBeingDebugged(IDMContext dmc) {
+        if (dmc instanceof TraceExecutionDMC) {
+            // Returning this specific execution context, the visualizer is
+            // unaware that the process
+            // and execution context are consolidated on this context
+            return new IDMContext[] { dmc };
+        }
+
+        Collection<TraceExecutionDMC> execDmcs = fMapCoreToExecution.values();
+        return execDmcs.toArray(new TraceExecutionDMC[execDmcs.size()]);
+    }
+
+    @Override
+    public IThreadDMData getExecutionData(IThreadDMContext dmc) {
+        assert (dmc != null && dmc instanceof TraceExecutionDMC);
+
+        return ((TraceExecutionDMC) dmc).getExecutionData();
+    }
+
+    // IRunControl related API
+    @Override
+    public IExecutionDMData getExecutionData(IExecutionDMContext dmc) {
+        return new IExecutionDMData() {
+
+            @Override
+            public StateChangeReason getStateChangeReason() {
+                return StateChangeReason.UNKNOWN;
+            }
+        };
+    }
+}

--- a/org.eclipse.tracecompass.dsf.core/src/org/eclipse/tracecompass/internal/dsf/core/service/DsfTraceModelService.java
+++ b/org.eclipse.tracecompass.dsf.core/src/org/eclipse/tracecompass/internal/dsf/core/service/DsfTraceModelService.java
@@ -61,6 +61,7 @@ import org.eclipse.tracecompass.tmf.core.signal.TmfRangeSynchSignal;
 import org.eclipse.tracecompass.tmf.core.signal.TmfSignalHandler;
 import org.eclipse.tracecompass.tmf.core.signal.TmfSignalManager;
 import org.eclipse.tracecompass.tmf.core.signal.TmfTimeSynchSignal;
+import org.eclipse.tracecompass.tmf.core.signal.TmfTraceSelectedSignal;
 import org.eclipse.tracecompass.tmf.core.statesystem.TmfStateSystemAnalysisModule;
 import org.eclipse.tracecompass.tmf.core.timestamp.TmfTimeRange;
 import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
@@ -78,6 +79,7 @@ public class DsfTraceModelService extends AbstractDsfService implements IDsfTrac
     private long fEndTime;
     private ICommandControlDMContext fCommandControlContext;
     private Map<ICoreDMContext, TraceExecutionDMC> fMapCoreToExecution = new HashMap<>();
+    private boolean fTraceActive = true;
 
     @Immutable
     private class GDBCPUDMC extends AbstractDMContext implements ICPUDMContext
@@ -366,6 +368,10 @@ public class DsfTraceModelService extends AbstractDsfService implements IDsfTrac
      */
     @TmfSignalHandler
     public void timeSelected(TmfTimeSynchSignal signal) {
+        if (!fTraceActive) {
+            return;
+        }
+
         // Broadcasted in nano seconds
         long beginTime = signal.getBeginTime().getValue();
         long endTime = signal.getEndTime().getValue();
@@ -397,6 +403,10 @@ public class DsfTraceModelService extends AbstractDsfService implements IDsfTrac
      */
     @TmfSignalHandler
     public void timeRangeSelected(TmfRangeSynchSignal signal) {
+        if (!fTraceActive) {
+            return;
+        }
+
         // Broadcasted in nano seconds
         TmfTimeRange timeRange = signal.getCurrentRange();
         fStartTime = timeRange.getStartTime().getValue();
@@ -404,6 +414,20 @@ public class DsfTraceModelService extends AbstractDsfService implements IDsfTrac
         System.out.println("Time Range selected: " + fStartTime + "->" + fEndTime);
         reset();
     }
+
+    /**
+     * @param signal -
+     */
+    @TmfSignalHandler
+    public void traceSelected(TmfTraceSelectedSignal signal) {
+        ITmfTrace activeTrace = signal.getTrace();
+        if (activeTrace == fTrace) {
+            fTraceActive = true;
+        } else {
+            fTraceActive = false;
+        }
+    }
+
 
     /**
      * @return The bundle context of the plug-in to which this service belongs.

--- a/org.eclipse.tracecompass.dsf.core/src/org/eclipse/tracecompass/internal/dsf/core/service/IDsfTraceModelService.java
+++ b/org.eclipse.tracecompass.dsf.core/src/org/eclipse/tracecompass/internal/dsf/core/service/IDsfTraceModelService.java
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Ericsson.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Alvaro Sanchez-Leon (Ericsson) - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tracecompass.internal.dsf.core.service;
+
+import org.eclipse.cdt.dsf.datamodel.IDMContext;
+import org.eclipse.cdt.dsf.debug.service.IProcesses.IThreadDMContext;
+import org.eclipse.cdt.dsf.debug.service.IProcesses.IThreadDMData;
+import org.eclipse.cdt.dsf.debug.service.IRunControl.IExecutionDMContext;
+import org.eclipse.cdt.dsf.debug.service.IRunControl.IExecutionDMData;
+import org.eclipse.cdt.dsf.gdb.service.IGDBHardwareAndOS.ICPUDMContext;
+import org.eclipse.cdt.dsf.gdb.service.IGDBHardwareAndOS.ICoreDMContext;
+import org.eclipse.cdt.dsf.gdb.service.IGDBHardwareAndOS.IHardwareTargetDMContext;
+import org.eclipse.cdt.dsf.gdb.service.IGDBHardwareAndOS2.ILoadInfo;
+import org.eclipse.core.runtime.CoreException;
+
+/**
+ * Consolidating the API Services needed by the Multi-core visualizer
+ *
+ */
+public interface IDsfTraceModelService {
+    /*********************/
+    /* HW OS related API */
+    /*********************/
+
+    /**
+     * @param dmc -
+     * @return - All known CPU's at the currently selected time on the associated trace
+     */
+    public ICPUDMContext[] getCPUs(final IHardwareTargetDMContext dmc);
+
+    /**
+     * @param dmc -
+     * @return - All known Cores at the currently selected time on the associated trace
+     */
+    public ICoreDMContext[] getCores(IDMContext dmc);
+
+    /**
+     * @param targetDmc - Parent context
+     * @param CPUId -
+     * @return - Created instance
+     */
+    public ICPUDMContext createCPUContext(IHardwareTargetDMContext targetDmc, String CPUId);
+
+    /**
+     * @param context - Specific context for the resolution of the load
+     * @return - The resolved load information
+     * @throws CoreException -
+     */
+    public ILoadInfo getLoadInfo(IDMContext context) throws CoreException;
+
+    /*************************/
+    /* Processes related API */
+    /*************************/
+    /**
+     * @param dmc - Processes known under the given context
+     * @return - known processes contexts associated to the given context
+     */
+    public IDMContext[] getProcessesBeingDebugged(IDMContext dmc);
+
+    /**
+     * @param dmc -
+     * @return - The thread data corresponding to the given context
+     */
+    public IThreadDMData getExecutionData(IThreadDMContext dmc);
+
+    /***************************/
+    /* IRunControl related API */
+    /***************************/
+    /**
+     * @param dmc -
+     * @return - The execution data associated to the given context
+     */
+    public IExecutionDMData getExecutionData(IExecutionDMContext dmc);
+}

--- a/org.eclipse.tracecompass.dsf.core/src/org/eclipse/tracecompass/internal/dsf/core/service/TraceCommandControlService.java
+++ b/org.eclipse.tracecompass.dsf.core/src/org/eclipse/tracecompass/internal/dsf/core/service/TraceCommandControlService.java
@@ -61,7 +61,7 @@ public class TraceCommandControlService extends AbstractDsfService implements IC
 
         @Override
         public String getCommandControlId() {
-            return "0"; //$NON-NLS-1$
+            return getSessionId();
         }
     }
 

--- a/org.eclipse.tracecompass.dsf.core/src/org/eclipse/tracecompass/internal/dsf/core/service/TraceHardwareAndOSService.java
+++ b/org.eclipse.tracecompass.dsf.core/src/org/eclipse/tracecompass/internal/dsf/core/service/TraceHardwareAndOSService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 Ericsson.
+ * Copyright (c) 2015 Ericsson.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,206 +10,23 @@
  *******************************************************************************/
 package org.eclipse.tracecompass.internal.dsf.core.service;
 
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.Hashtable;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 import org.eclipse.cdt.dsf.concurrent.DataRequestMonitor;
-import org.eclipse.cdt.dsf.concurrent.ImmediateDataRequestMonitor;
-import org.eclipse.cdt.dsf.concurrent.ImmediateExecutor;
-import org.eclipse.cdt.dsf.concurrent.Immutable;
 import org.eclipse.cdt.dsf.concurrent.RequestMonitor;
-import org.eclipse.cdt.dsf.datamodel.AbstractDMContext;
-import org.eclipse.cdt.dsf.datamodel.DMContexts;
 import org.eclipse.cdt.dsf.datamodel.IDMContext;
 import org.eclipse.cdt.dsf.datamodel.IDMData;
 import org.eclipse.cdt.dsf.debug.service.ICachingService;
 import org.eclipse.cdt.dsf.gdb.service.IGDBHardwareAndOS;
 import org.eclipse.cdt.dsf.gdb.service.IGDBHardwareAndOS2;
-import org.eclipse.cdt.dsf.service.AbstractDsfService;
 import org.eclipse.cdt.dsf.service.DsfSession;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.jdt.annotation.NonNull;
-import org.eclipse.tracecompass.analysis.os.linux.core.cpuusage.KernelCpuUsageAnalysis;
-import org.eclipse.tracecompass.analysis.os.linux.core.kernelanalysis.Attributes;
-import org.eclipse.tracecompass.analysis.os.linux.core.kernelanalysis.KernelAnalysis;
 import org.eclipse.tracecompass.internal.dsf.core.DsfTraceCorePlugin;
-import org.eclipse.tracecompass.statesystem.core.ITmfStateSystem;
-import org.eclipse.tracecompass.statesystem.core.exceptions.AttributeNotFoundException;
-import org.eclipse.tracecompass.statesystem.core.exceptions.StateSystemDisposedException;
-import org.eclipse.tracecompass.statesystem.core.exceptions.StateValueTypeException;
-import org.eclipse.tracecompass.statesystem.core.exceptions.TimeRangeException;
-import org.eclipse.tracecompass.statesystem.core.interval.ITmfStateInterval;
-import org.eclipse.tracecompass.statesystem.core.statevalue.ITmfStateValue;
-import org.eclipse.tracecompass.tmf.core.signal.TmfRangeSynchSignal;
-import org.eclipse.tracecompass.tmf.core.signal.TmfSignalHandler;
-import org.eclipse.tracecompass.tmf.core.signal.TmfSignalManager;
-import org.eclipse.tracecompass.tmf.core.signal.TmfTimeSynchSignal;
-import org.eclipse.tracecompass.tmf.core.statesystem.TmfStateSystemAnalysisModule;
-import org.eclipse.tracecompass.tmf.core.timestamp.TmfTimeRange;
-import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
-import org.eclipse.tracecompass.tmf.core.trace.TmfTraceUtils;
-import org.osgi.framework.BundleContext;
 
-/** */
-public class TraceHardwareAndOSService extends AbstractDsfService implements IGDBHardwareAndOS2, ICachingService {
-
-    final private ITmfTrace fTrace;
-    final private KernelCpuUsageAnalysis fCPUModule;
-    final private ITmfStateSystem fStateSys;
-    final private Map<ICPUDMContext, ICoreDMContext[]> fMapCPUToCores = new HashMap<>();
-    private long fStartTime;
-    private long fEndTime;
-
-    @Immutable
-    private static class GDBCPUDMC extends AbstractDMContext
-            implements ICPUDMContext
-    {
-        /**
-         * String ID that is used to identify the thread in the GDB/MI protocol.
-         */
-        private final String fId;
-
-        /**
-         * @param sessionId
-         *            The session
-         * @param targetDmc
-         *            The target
-         * @param id
-         *            the CPU id
-         */
-        protected GDBCPUDMC(String sessionId, IHardwareTargetDMContext targetDmc, String id) {
-            super(sessionId, targetDmc == null ? new IDMContext[0] : new IDMContext[] { targetDmc });
-            fId = id;
-        }
-
-        @Override
-        public String getId() {
-            return fId;
-        }
-
-        @Override
-        public String toString() {
-            return baseToString() + ".CPU[" + fId + "]";} //$NON-NLS-1$ //$NON-NLS-2$
-
-        @Override
-        public boolean equals(Object obj) {
-            return baseEquals(obj) && ((GDBCPUDMC) obj).fId.equals(fId);
-        }
-
-        @Override
-        public int hashCode() {
-            return baseHashCode() ^ fId.hashCode();
-        }
-    }
-
-    @Immutable
-    private static class GDBCoreDMC extends AbstractDMContext
-            implements ICoreDMContext
-    {
-        /**
-         * E.g. The name given to the State system node representing a cpu core
-         */
-        private final String fId;
-        /**
-         * The node in the Tmftrace State system,
-         */
-        private final Integer fNode;
-
-        public GDBCoreDMC(String sessionId, ICPUDMContext CPUDmc, Integer coreNode, String id) {
-            super(sessionId, CPUDmc == null ? new IDMContext[0] : new IDMContext[] { CPUDmc });
-            fId = id;
-            fNode = coreNode;
-        }
-
-        @Override
-        public String getId() {
-            return fId;
-        }
-
-        // The State system node is the key to access any additional
-        // information, however the value does not represent the actual core id
-        public Integer getNode() {
-            return fNode;
-        }
-
-        @Override
-        public String toString() {
-            return baseToString() + ".core[" + fId + "]";} //$NON-NLS-1$ //$NON-NLS-2$
-
-        @Override
-        public boolean equals(Object obj) {
-            return baseEquals(obj) &&
-                    (((GDBCoreDMC) obj).fId == null ? fId == null : ((GDBCoreDMC) obj).fId.equals(fId));
-        }
-
-        @Override
-        public int hashCode() {
-            return baseHashCode() ^ (fId == null ? 0 : fId.hashCode());
-        }
-    }
-
-    // @Immutable
-    // private static class GDBCPUDMData implements ICPUDMData {
-    // final int fNumCores;
-    //
-    // public GDBCPUDMData(int num) {
-    // fNumCores = num;
-    // }
-    //
-    // @Override
-    // public int getNumCores() { return fNumCores; }
-    // }
-    //
-    // @Immutable
-    // private static class GDBCoreDMData implements ICoreDMData {
-    // final String fPhysicalId;
-    //
-    // public GDBCoreDMData(String id) {
-    // fPhysicalId = id;
-    // }
-    //
-    // @Override
-    // public String getPhysicalId() { return fPhysicalId; }
-    // }
-
-    @Immutable
-    private class GDBLoadInfo implements ILoadInfo {
-        private int fILoad;
-        private String fLoad;
-        private Map<String, String> fDetailedLoad;
-
-        public GDBLoadInfo(String load, Map<String, String> detailedLoad) {
-            fLoad = load;
-            fILoad = Integer.valueOf(load);
-            fDetailedLoad = detailedLoad;
-        }
-
-        public GDBLoadInfo(int load) {
-            this(String.valueOf(load), null);
-            fILoad = load;
-        }
-
-        public int getILoad() {
-            return fILoad;
-        }
-
-        @Override
-        public String getLoad() {
-            return fLoad;
-        }
-
-        @Override
-        public Map<String, String> getDetailedLoad() {
-            return fDetailedLoad;
-        }
-    }
-
+public class TraceHardwareAndOSService extends AbstractDsfTraceService implements IGDBHardwareAndOS2, ICachingService {
     /**
      * @param session
      *            The DSF session for this service.
@@ -217,48 +34,8 @@ public class TraceHardwareAndOSService extends AbstractDsfService implements IGD
      *            The trace associated to this service
      * @throws CoreException
      */
-    public TraceHardwareAndOSService(@NonNull DsfSession session, @NonNull ITmfTrace trace) throws CoreException {
+    public TraceHardwareAndOSService(@NonNull DsfSession session) throws CoreException {
         super(session);
-
-        // Use VIP to make sure the time selection is first updated in this
-        // service i.e. before the UI queries for the load
-        TmfSignalManager.registerVIP(this);
-
-        fTrace = trace;
-
-        // initialize cpu data source
-        fCPUModule = TmfTraceUtils.getAnalysisModuleOfClass(fTrace, KernelCpuUsageAnalysis.class, KernelCpuUsageAnalysis.ID);
-        if (fCPUModule == null) {
-            // Notify of incorrect initialization
-            throw new CoreException(new Status(IStatus.ERROR, DsfTraceCorePlugin.PLUGIN_ID, INVALID_HANDLE, "Unable to resolve Cpu Usage Analysis module from trace: " + trace, null)); //$NON-NLS-1$
-        }
-
-        fCPUModule.schedule();
-        fCPUModule.waitForInitialization();
-        fStateSys = fCPUModule.getStateSystem();
-        if (fStateSys == null) {
-            // Notify of incorrect initialization
-            throw new CoreException(new Status(IStatus.ERROR, DsfTraceCorePlugin.PLUGIN_ID, INVALID_HANDLE, "Unable to resolve the State System from trace: " + trace, null)); //$NON-NLS-1$
-        }
-
-        fStartTime = fStateSys.getStartTime();
-        fEndTime = fStateSys.getCurrentEndTime();
-    }
-
-    /**
-     * This method initializes this service.
-     *
-     * @param requestMonitor
-     *            The request monitor indicating the operation is finished
-     */
-    @Override
-    public void initialize(final RequestMonitor requestMonitor) {
-        super.initialize(new RequestMonitor(ImmediateExecutor.getInstance(), requestMonitor) {
-            @Override
-            protected void handleSuccess() {
-                doInitialize(requestMonitor);
-            }
-        });
     }
 
     /**
@@ -269,7 +46,8 @@ public class TraceHardwareAndOSService extends AbstractDsfService implements IGD
      *            The call-back object to notify when this service's
      *            initialization is done.
      */
-    private void doInitialize(RequestMonitor requestMonitor) {
+    @Override
+    protected void doInitialize(RequestMonitor requestMonitor) {
         // Register this service.
         register(new String[] { IGDBHardwareAndOS.class.getName(),
                 IGDBHardwareAndOS2.class.getName(),
@@ -280,112 +58,13 @@ public class TraceHardwareAndOSService extends AbstractDsfService implements IGD
     }
 
     @Override
-    public void shutdown(RequestMonitor requestMonitor) {
-        TmfSignalManager.deregister(this);
-        fMapCPUToCores.clear();
-        unregister();
-        super.shutdown(requestMonitor);
-    }
-
-    /**
-     * Resolve the time interval to use for the calculation of load
-     * @param signal -
-     */
-    @TmfSignalHandler
-    public void timeSelected(TmfTimeSynchSignal signal) {
-        // Broadcasted in nano seconds
-        long beginTime = signal.getBeginTime().getValue();
-        long endTime = signal.getEndTime().getValue();
-        fEndTime = endTime;
-        if (beginTime == endTime) {
-            // calculate load period over previous 1/2000 of the trace's time range
-            long delta = (fStateSys.getCurrentEndTime() - fStateSys.getStartTime()) / 2000;
-            fStartTime = fEndTime - delta;
-        } else {
-            fStartTime = beginTime;
-        }
-
-        assert fEndTime > fStartTime;
-        System.out.println("Current end time: " + fStateSys.getCurrentEndTime());
-        System.out.println("Time Selected: " + fStartTime + "->" + fEndTime + ": " + (fEndTime - fStartTime));
-    }
-
-    /**
-     * @param signal
-     */
-    @TmfSignalHandler
-    public void timeRangeSelected(TmfRangeSynchSignal signal) {
-        // Broadcasted in nano seconds
-        TmfTimeRange timeRange = signal.getCurrentRange();
-        fStartTime = timeRange.getStartTime().getValue();
-        fEndTime = timeRange.getStartTime().getValue();
-        System.out.println("Time Range selected: " + fStartTime + "->" + fEndTime);
-    }
-
-    /**
-     * @return The bundle context of the plug-in to which this service belongs.
-     */
-    @Override
-    protected BundleContext getBundleContext() {
-        return DsfTraceCorePlugin.getBundleContext();
-    }
-
-    @Override
     public void getCPUs(final IHardwareTargetDMContext dmc, final DataRequestMonitor<ICPUDMContext[]> rm) {
-        if (fMapCPUToCores.keySet().size() > 0) {
-            // CPU's already resolved for the associated trace
-            ICPUDMContext[] cpus = fMapCPUToCores.keySet().toArray(new ICPUDMContext[fMapCPUToCores.size()]);
-            System.out.println("getCPUs, returning cpus from map: " + cpus.length);
-            rm.done(cpus);
-            return;
-        }
-
-        rm.done(resolveCPUContexts(dmc));
+        rm.done(fModelService.getCPUs(dmc));
     }
 
     @Override
     public void getCores(IDMContext dmc, final DataRequestMonitor<ICoreDMContext[]> rm) {
-        ICPUDMContext cpuDmc = DMContexts.getAncestorOfType(dmc, ICPUDMContext.class);
-
-        if (cpuDmc == null) {
-            // Retrieve all available cores
-           Set<ICPUDMContext> cpus = fMapCPUToCores.keySet();
-           if (cpus.size() < 1) {
-               // Most likely not yet initialized, try to resolve the CPUs
-               getCPUs(null, new ImmediateDataRequestMonitor<IGDBHardwareAndOS.ICPUDMContext[]>() {
-               });
-           }
-
-           rm.done(getAllCores());
-           return;
-        }
-
-        // Check if the ICoreDMContexts exist in our cpu map
-        ICoreDMContext[] coreDmcs = fMapCPUToCores.get(cpuDmc);
-        if (coreDmcs != null) {
-            // We have previously resolved the cores, so lets return them
-            rm.done(coreDmcs);
-            return;
-        }
-
-        // Not available but cpu context is not null, not expected but we can assume there are no core context on this trace
-        rm.done(new ICoreDMContext[0]);
-    }
-
-    private ICoreDMContext[] getAllCores() {
-        List<ICoreDMContext> cores = new ArrayList<>();
-        Set<ICPUDMContext> cpus = fMapCPUToCores.keySet();
-        if (cpus.size() > 0) {
-            for (ICPUDMContext cpu : cpus) {
-                ICoreDMContext[] coreDmcs = fMapCPUToCores.get(cpu);
-                for (ICoreDMContext coreDmc : coreDmcs) {
-                    cores.add(coreDmc);
-                }
-            }
-        }
-
-        System.out.println("getAllCores, returning " + cores.size() + ", cores");
-        return new ICoreDMContext[cores.size()];
+        rm.done(fModelService.getCores(dmc));
     }
 
     @Override
@@ -401,48 +80,15 @@ public class TraceHardwareAndOSService extends AbstractDsfService implements IGD
 
     @Override
     public ICPUDMContext createCPUContext(IHardwareTargetDMContext targetDmc, String CPUId) {
-        ICPUDMContext cpuDmc = new GDBCPUDMC(getSession().getId(), targetDmc, CPUId);
-        // Lets leave the resolution of cores to its actual call
-        fMapCPUToCores.put(cpuDmc, null);
-        return cpuDmc;
+        return fModelService.createCPUContext(targetDmc, CPUId);
     }
 
-    /**
-     * Need to resolve the associated CPU's anc Cores
-     *
-     * TODO: Trace compass does not seem to
-     * divide core and cpu today, For now lets go with one CORE per CPU,
-     * and use the Trace compass CPU's as cores
-     *
-     * @param dmc
-     * @return
-     */
-    private ICPUDMContext[] resolveCPUContexts(IHardwareTargetDMContext dmc) {
-        // For now treat a TRACE-CPU as Core and associate it with a local CPU context
+    @Override
+    public void getLoadInfo(final IDMContext context, final DataRequestMonitor<ILoadInfo> rm) {
         try {
-            int coreSSNode = fStateSys.getQuarkAbsolute(Attributes.CPUS);
-            List<Integer> coreNodes = fStateSys.getSubAttributes(coreSSNode, false);
-
-            // Represent it as one core per CPU
-            ICPUDMContext[] cpuDmcs = new ICPUDMContext[coreNodes.size()];
-            int i = 0;
-            for (Integer coreNode : coreNodes) {
-                String coreName = fStateSys.getAttributeName(coreNode);
-                ICPUDMContext cpuDmc = cpuDmcs[i] = createCPUContext(dmc, String.valueOf(i));
-                ICoreDMContext[] coreDmcs = new ICoreDMContext[]{createCoreContext(cpuDmcs[i], coreNode, coreName)};
-                fMapCPUToCores.put(cpuDmc, coreDmcs);
-                System.out.println("resolved core #" + coreName);
-                i++;
-            }
-
-            // Normal scenario, returning contexts for each CPU
-            System.out.println("resolved " + cpuDmcs.length + " CPUs"); //$NON-NLS-1$ //$NON-NLS-2$
-
-            return cpuDmcs;
-        } catch (AttributeNotFoundException e) {
-            // No core attributes found
-            System.out.println("State system, AttributeNotfound");
-            return new ICPUDMContext[0];
+            rm.done(fModelService.getLoadInfo(context));
+        } catch (CoreException e) {
+            rm.done(e.getStatus());
         }
     }
 
@@ -453,19 +99,6 @@ public class TraceHardwareAndOSService extends AbstractDsfService implements IGD
         // the private method below
         assert false;
         return null;
-    }
-
-    /**
-     * @param cpuDmc
-     *            - Parent cpu context
-     * @param coreNode
-     *            - Reference to the state system model
-     * @param coreId
-     *            - Id displayed by the UI
-     * @return - The created core context
-     */
-    public ICoreDMContext createCoreContext(ICPUDMContext cpuDmc, Integer coreNode, String coreId) {
-        return new GDBCoreDMC(getSession().getId(), cpuDmc, coreNode, coreId);
     }
 
     @Override
@@ -487,144 +120,6 @@ public class TraceHardwareAndOSService extends AbstractDsfService implements IGD
     public void getResourcesInformation(IDMContext dmc, String resourceClassId,
             DataRequestMonitor<IResourcesInformation> rm) {
         rm.done(new Status(IStatus.ERROR, DsfTraceCorePlugin.PLUGIN_ID, NOT_SUPPORTED, "Operation not supported", null)); //$NON-NLS-1$
-    }
-
-    @Override
-    public void getLoadInfo(final IDMContext context, final DataRequestMonitor<ILoadInfo> rm) {
-        if (context instanceof ICoreDMContext) {
-            System.out.println("********** CORE **************");
-            rm.done(getCoreLoadInfo((ICoreDMContext) context));
-            return;
-        }
-
-        if (context instanceof ICPUDMContext) {
-            System.out.println("*********** CPU *************");
-            // Resolve the load for given cpu context
-            rm.done(getCPULoadInfo((ICPUDMContext) context));
-            return;
-        }
-
-        // we only support getting the load for a CPU or a core
-        rm.done(new Status(IStatus.ERROR, DsfTraceCorePlugin.PLUGIN_ID, INVALID_HANDLE, "Load information not supported for this context type", null)); //$NON-NLS-1$
-        return;
-
-    }
-
-    private void getActiveThread(ICoreDMContext coreDmc) {
-        // Validate context, and provide a handle to the internal class
-        // implementation
-        assert (coreDmc instanceof GDBCoreDMC);
-        GDBCoreDMC context = (GDBCoreDMC) coreDmc;
-
-        ITmfStateSystem ss = TmfStateSystemAnalysisModule.getStateSystem(fTrace, KernelAnalysis.ID);
-        if (ss != null) {
-            String execName = "";
-            int currentThreadId = 0;
-
-            try {
-                int cpuQuark = resolveKernelCpuQuark(ss, context.fId);
-                int currentThreadQuark = ss.getQuarkRelative(cpuQuark, Attributes.CURRENT_THREAD);
-                ITmfStateInterval interval = ss.querySingleState(fEndTime, currentThreadQuark);
-                if (!interval.getStateValue().isNull()) {
-                    ITmfStateValue value = interval.getStateValue();
-                    currentThreadId = value.unboxInt();
-
-                    int execNameQuark = ss.getQuarkAbsolute(Attributes.THREADS, Integer.toString(currentThreadId), Attributes.EXEC_NAME);
-                    interval = ss.querySingleState(fEndTime, execNameQuark);
-                    if (!interval.getStateValue().isNull()) {
-                        value = interval.getStateValue();
-                        execName = value.unboxStr();
-                    }
-                }
-
-                System.out.println("Current Thread id: " + currentThreadId + "\nCurrent executable: " + execName); //$NON-NLS-1$
-
-            } catch (AttributeNotFoundException | TimeRangeException | StateValueTypeException e) {
-                System.out.println("Error resolving active thread"); //$NON-NLS-1$
-                e.printStackTrace();
-            } catch (StateSystemDisposedException e) {
-                /* Ignored */
-            }
-        }
-    }
-
-    private static int resolveKernelCpuQuark(ITmfStateSystem ss, String coreName) throws AttributeNotFoundException {
-        int cpusNode = ss.getQuarkAbsolute(Attributes.CPUS);
-        List<Integer> cpuNodes = ss.getSubAttributes(cpusNode, false);
-
-        //Get the names to match against the name on the cpu state system
-
-        int ssNode = -1;
-        // Resolve the selected cpu node quark on the kernel ss
-        for (int cpuNode : cpuNodes) {
-                String ssCpuName = ss.getAttributeName(cpuNode);
-                if (ssCpuName.equals(coreName)) {
-                        ssNode = cpuNode;
-                        break;
-                }
-        }
-
-        return ssNode;
-    }
-
-    private ILoadInfo getCoreLoadInfo(ICoreDMContext coreDmc) {
-        long startTime = fStartTime;
-        long endTime = fEndTime;
-
-        double duration = endTime - startTime;
-
-        // validate time ranges and prevent division by zero
-        if (duration < 1) {
-            assert false;
-            throw new TimeRangeException();
-        }
-
-        // Validate context, and provide a handle to the internal class
-        // implementation
-        assert (coreDmc instanceof GDBCoreDMC);
-        GDBCoreDMC context = (GDBCoreDMC) coreDmc;
-
-        Integer[] coreNode = new Integer[] { context.getNode() };
-
-        Map<String, Long> tidToCPUTime = fCPUModule.getCpuUsageInRange(coreNode, startTime, endTime);
-
-        // The map from thread to time spent includes a grand total identified
-        // with the key "total"
-        double totCpuTime = tidToCPUTime.get("total"); //$NON-NLS-1$
-        String cpuName = fStateSys.getAttributeName(context.getNode());
-        // The idle time is represented by a thread id of zero over the
-        // following key=value format "cpuname/threadId=value"
-        double idleCpuTime = tidToCPUTime.get(cpuName + "/0"); //$NON-NLS-1$
-        totCpuTime = totCpuTime - idleCpuTime;
-
-        double loadPercent = (totCpuTime / duration) * 100;
-        System.out.println("Core " + context.getId() + ", load: " + (int) loadPercent);
-
-        getActiveThread(coreDmc);
-
-        return new GDBLoadInfo((int) loadPercent);
-    }
-
-    private ILoadInfo getCPULoadInfo(ICPUDMContext cpuDmc) {
-        int loadInfo = 0;
-
-        // Resolve the context for the cores
-        ICoreDMContext[] coreDmcs = fMapCPUToCores.get(cpuDmc);
-
-        if (coreDmcs != null && coreDmcs.length > 0) {
-            for (ICoreDMContext core : coreDmcs) {
-                ILoadInfo coreLoadInfo = getCoreLoadInfo(core);
-                assert (coreLoadInfo instanceof GDBLoadInfo);
-                loadInfo += ((GDBLoadInfo) coreLoadInfo).getILoad();
-            }
-
-            // Take average load of all cores
-            loadInfo = loadInfo / coreDmcs.length;
-        }
-
-        System.out.println("CPU load: " + cpuDmc.getId() + "->" +  loadInfo + "\n"); //$NON-NLS-1$
-
-        return new GDBLoadInfo(loadInfo);
     }
 
 }

--- a/org.eclipse.tracecompass.dsf.core/src/org/eclipse/tracecompass/internal/dsf/core/service/TraceHardwareAndOSService.java
+++ b/org.eclipse.tracecompass.dsf.core/src/org/eclipse/tracecompass/internal/dsf/core/service/TraceHardwareAndOSService.java
@@ -36,8 +36,8 @@ import org.eclipse.core.runtime.Status;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.tracecompass.analysis.os.linux.core.cpuusage.KernelCpuUsageAnalysis;
 import org.eclipse.tracecompass.analysis.os.linux.core.kernelanalysis.Attributes;
+import org.eclipse.tracecompass.analysis.os.linux.core.kernelanalysis.KernelAnalysis;
 import org.eclipse.tracecompass.internal.dsf.core.DsfTraceCorePlugin;
-import org.eclipse.tracecompass.lttng2.kernel.core.analysis.kernel.LttngKernelAnalysis;
 import org.eclipse.tracecompass.statesystem.core.ITmfStateSystem;
 import org.eclipse.tracecompass.statesystem.core.exceptions.AttributeNotFoundException;
 import org.eclipse.tracecompass.statesystem.core.exceptions.StateSystemDisposedException;
@@ -506,7 +506,7 @@ public class TraceHardwareAndOSService extends AbstractDsfService implements IGD
         assert (coreDmc instanceof GDBCoreDMC);
         GDBCoreDMC context = (GDBCoreDMC) coreDmc;
 
-        ITmfStateSystem ss = TmfStateSystemAnalysisModule.getStateSystem(fTrace, LttngKernelAnalysis.ID);
+        ITmfStateSystem ss = TmfStateSystemAnalysisModule.getStateSystem(fTrace, KernelAnalysis.ID);
         if (ss != null) {
             String execName = "";
             int currentThreadId = 0;

--- a/org.eclipse.tracecompass.dsf.core/src/org/eclipse/tracecompass/internal/dsf/core/service/TraceProcessesService.java
+++ b/org.eclipse.tracecompass.dsf.core/src/org/eclipse/tracecompass/internal/dsf/core/service/TraceProcessesService.java
@@ -1,0 +1,173 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Ericsson.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Alvaro Sanchez-Leon (Ericsson) - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tracecompass.internal.dsf.core.service;
+
+import java.util.Hashtable;
+import java.util.Map;
+
+import org.eclipse.cdt.dsf.concurrent.DataRequestMonitor;
+import org.eclipse.cdt.dsf.concurrent.RequestMonitor;
+import org.eclipse.cdt.dsf.datamodel.IDMContext;
+import org.eclipse.cdt.dsf.debug.service.IProcesses;
+import org.eclipse.cdt.dsf.service.DsfSession;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.tracecompass.internal.dsf.core.DsfTraceCorePlugin;
+
+
+/**
+ * Process Service proxy to the DSF Trace model
+ *
+ */
+public class TraceProcessesService extends AbstractDsfTraceService implements IProcesses {
+
+
+    /**
+     * @param session - Session where an instance of this service will participate
+     * @throws CoreException -
+     */
+    public TraceProcessesService(@NonNull DsfSession session) throws CoreException {
+        super(session);
+    }
+
+    /**
+     * This method initializes this service after our superclass's initialize()
+     * method succeeds.
+     *
+     * @param requestMonitor
+     *            The call-back object to notify when this service's
+     *            initialization is done.
+     */
+    @Override
+    protected void doInitialize(RequestMonitor requestMonitor) {
+        // Register this service.
+        register(new String[] { IProcesses.class.getName(),
+                TraceProcessesService.class.getName() },
+                new Hashtable<String, String>());
+
+        requestMonitor.done();
+    }
+
+
+    /* (non-Javadoc)
+     * @see org.eclipse.cdt.dsf.debug.service.IProcesses#getProcessesBeingDebugged(org.eclipse.cdt.dsf.datamodel.IDMContext, org.eclipse.cdt.dsf.concurrent.DataRequestMonitor)
+     */
+    @Override
+    public void getProcessesBeingDebugged(IDMContext dmc, DataRequestMonitor<IDMContext[]> rm) {
+        rm.done(fModelService.getProcessesBeingDebugged(dmc));
+    }
+
+    /* (non-Javadoc)
+     * @see org.eclipse.cdt.dsf.debug.service.IProcesses#getExecutionData(org.eclipse.cdt.dsf.debug.service.IProcesses.IThreadDMContext, org.eclipse.cdt.dsf.concurrent.DataRequestMonitor)
+     */
+    @Override
+    public void getExecutionData(IThreadDMContext dmc, DataRequestMonitor<IThreadDMData> rm) {
+        rm.done(fModelService.getExecutionData(dmc));
+    }
+
+    /* (non-Javadoc)
+     * @see org.eclipse.cdt.dsf.debug.service.IProcesses#getDebuggingContext(org.eclipse.cdt.dsf.debug.service.IProcesses.IThreadDMContext, org.eclipse.cdt.dsf.concurrent.DataRequestMonitor)
+     */
+    @Override
+    public void getDebuggingContext(IThreadDMContext dmc, DataRequestMonitor<IDMContext> rm) {
+        rm.done(new Status(IStatus.ERROR, DsfTraceCorePlugin.PLUGIN_ID, NOT_SUPPORTED, "Operation not supported", null)); //$NON-NLS-1$
+    }
+
+    /* (non-Javadoc)
+     * @see org.eclipse.cdt.dsf.debug.service.IProcesses#getRunningProcesses(org.eclipse.cdt.dsf.datamodel.IDMContext, org.eclipse.cdt.dsf.concurrent.DataRequestMonitor)
+     */
+    @Override
+    public void getRunningProcesses(IDMContext dmc, DataRequestMonitor<IProcessDMContext[]> rm) {
+        rm.done(new Status(IStatus.ERROR, DsfTraceCorePlugin.PLUGIN_ID, NOT_SUPPORTED, "Operation not supported", null)); //$NON-NLS-1$
+    }
+
+    /* (non-Javadoc)
+     * @see org.eclipse.cdt.dsf.debug.service.IProcesses#isDebuggerAttachSupported(org.eclipse.cdt.dsf.datamodel.IDMContext, org.eclipse.cdt.dsf.concurrent.DataRequestMonitor)
+     */
+    @Override
+    public void isDebuggerAttachSupported(IDMContext dmc, DataRequestMonitor<Boolean> rm) {
+        rm.done(new Status(IStatus.ERROR, DsfTraceCorePlugin.PLUGIN_ID, NOT_SUPPORTED, "Operation not supported", null)); //$NON-NLS-1$
+    }
+
+    /* (non-Javadoc)
+     * @see org.eclipse.cdt.dsf.debug.service.IProcesses#attachDebuggerToProcess(org.eclipse.cdt.dsf.debug.service.IProcesses.IProcessDMContext, org.eclipse.cdt.dsf.concurrent.DataRequestMonitor)
+     */
+    @Override
+    public void attachDebuggerToProcess(IProcessDMContext procCtx, DataRequestMonitor<IDMContext> rm) {
+        rm.done(new Status(IStatus.ERROR, DsfTraceCorePlugin.PLUGIN_ID, NOT_SUPPORTED, "Operation not supported", null)); //$NON-NLS-1$
+    }
+
+    /* (non-Javadoc)
+     * @see org.eclipse.cdt.dsf.debug.service.IProcesses#canDetachDebuggerFromProcess(org.eclipse.cdt.dsf.datamodel.IDMContext, org.eclipse.cdt.dsf.concurrent.DataRequestMonitor)
+     */
+    @Override
+    public void canDetachDebuggerFromProcess(IDMContext dmc, DataRequestMonitor<Boolean> rm) {
+        rm.done(new Status(IStatus.ERROR, DsfTraceCorePlugin.PLUGIN_ID, NOT_SUPPORTED, "Operation not supported", null)); //$NON-NLS-1$
+    }
+
+    /* (non-Javadoc)
+     * @see org.eclipse.cdt.dsf.debug.service.IProcesses#detachDebuggerFromProcess(org.eclipse.cdt.dsf.datamodel.IDMContext, org.eclipse.cdt.dsf.concurrent.RequestMonitor)
+     */
+    @Override
+    public void detachDebuggerFromProcess(IDMContext dmc, RequestMonitor rm) {
+        rm.done(new Status(IStatus.ERROR, DsfTraceCorePlugin.PLUGIN_ID, NOT_SUPPORTED, "Operation not supported", null)); //$NON-NLS-1$
+    }
+
+    /* (non-Javadoc)
+     * @see org.eclipse.cdt.dsf.debug.service.IProcesses#isRunNewProcessSupported(org.eclipse.cdt.dsf.datamodel.IDMContext, org.eclipse.cdt.dsf.concurrent.DataRequestMonitor)
+     */
+    @Override
+    public void isRunNewProcessSupported(IDMContext dmc, DataRequestMonitor<Boolean> rm) {
+        rm.done(new Status(IStatus.ERROR, DsfTraceCorePlugin.PLUGIN_ID, NOT_SUPPORTED, "Operation not supported", null)); //$NON-NLS-1$
+    }
+
+    /* (non-Javadoc)
+     * @see org.eclipse.cdt.dsf.debug.service.IProcesses#runNewProcess(org.eclipse.cdt.dsf.datamodel.IDMContext, java.lang.String, java.util.Map, org.eclipse.cdt.dsf.concurrent.DataRequestMonitor)
+     */
+    @Override
+    public void runNewProcess(IDMContext dmc, String file, Map<String, Object> attributes, DataRequestMonitor<IProcessDMContext> rm) {
+        rm.done(new Status(IStatus.ERROR, DsfTraceCorePlugin.PLUGIN_ID, NOT_SUPPORTED, "Operation not supported", null)); //$NON-NLS-1$
+    }
+
+    /* (non-Javadoc)
+     * @see org.eclipse.cdt.dsf.debug.service.IProcesses#isDebugNewProcessSupported(org.eclipse.cdt.dsf.datamodel.IDMContext, org.eclipse.cdt.dsf.concurrent.DataRequestMonitor)
+     */
+    @Override
+    public void isDebugNewProcessSupported(IDMContext dmc, DataRequestMonitor<Boolean> rm) {
+        rm.done(new Status(IStatus.ERROR, DsfTraceCorePlugin.PLUGIN_ID, NOT_SUPPORTED, "Operation not supported", null)); //$NON-NLS-1$
+    }
+
+    /* (non-Javadoc)
+     * @see org.eclipse.cdt.dsf.debug.service.IProcesses#debugNewProcess(org.eclipse.cdt.dsf.datamodel.IDMContext, java.lang.String, java.util.Map, org.eclipse.cdt.dsf.concurrent.DataRequestMonitor)
+     */
+    @Override
+    public void debugNewProcess(IDMContext dmc, String file, Map<String, Object> attributes, DataRequestMonitor<IDMContext> rm) {
+        rm.done(new Status(IStatus.ERROR, DsfTraceCorePlugin.PLUGIN_ID, NOT_SUPPORTED, "Operation not supported", null)); //$NON-NLS-1$
+    }
+
+    /* (non-Javadoc)
+     * @see org.eclipse.cdt.dsf.debug.service.IProcesses#canTerminate(org.eclipse.cdt.dsf.debug.service.IProcesses.IThreadDMContext, org.eclipse.cdt.dsf.concurrent.DataRequestMonitor)
+     */
+    @Override
+    public void canTerminate(IThreadDMContext thread, DataRequestMonitor<Boolean> rm) {
+        rm.done(new Status(IStatus.ERROR, DsfTraceCorePlugin.PLUGIN_ID, NOT_SUPPORTED, "Operation not supported", null)); //$NON-NLS-1$
+    }
+
+    /* (non-Javadoc)
+     * @see org.eclipse.cdt.dsf.debug.service.IProcesses#terminate(org.eclipse.cdt.dsf.debug.service.IProcesses.IThreadDMContext, org.eclipse.cdt.dsf.concurrent.RequestMonitor)
+     */
+    @Override
+    public void terminate(IThreadDMContext thread, RequestMonitor rm) {
+        rm.done(new Status(IStatus.ERROR, DsfTraceCorePlugin.PLUGIN_ID, NOT_SUPPORTED, "Operation not supported", null)); //$NON-NLS-1$
+    }
+}

--- a/org.eclipse.tracecompass.dsf.core/src/org/eclipse/tracecompass/internal/dsf/core/service/TraceRunControlService.java
+++ b/org.eclipse.tracecompass.dsf.core/src/org/eclipse/tracecompass/internal/dsf/core/service/TraceRunControlService.java
@@ -1,0 +1,137 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Ericsson.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Alvaro Sanchez-Leon (Ericsson) - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tracecompass.internal.dsf.core.service;
+
+import java.util.Hashtable;
+
+import org.eclipse.cdt.dsf.concurrent.DataRequestMonitor;
+import org.eclipse.cdt.dsf.concurrent.RequestMonitor;
+import org.eclipse.cdt.dsf.debug.service.IRunControl;
+import org.eclipse.cdt.dsf.service.DsfSession;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.tracecompass.internal.dsf.core.DsfTraceCorePlugin;
+
+
+/**
+ * Run Control Service proxy to the DSF Trace model
+ *
+ */
+public class TraceRunControlService extends AbstractDsfTraceService implements IRunControl {
+
+    /**
+     * @param session - Session where an instance of this service will participate
+     * @throws CoreException -
+     */
+    public TraceRunControlService(@NonNull DsfSession session) throws CoreException {
+        super(session);
+    }
+
+    /**
+     * This method initializes this service after our superclass's initialize()
+     * method succeeds.
+     *
+     * @param requestMonitor
+     *            The call-back object to notify when this service's
+     *            initialization is done.
+     */
+    @Override
+    protected void doInitialize(RequestMonitor requestMonitor) {
+        // Register this service.
+        register(new String[] { IRunControl.class.getName(),
+                TraceRunControlService.class.getName() },
+                new Hashtable<String, String>());
+
+        requestMonitor.done();
+    }
+
+    /* (non-Javadoc)
+     * @see org.eclipse.cdt.dsf.debug.service.IRunControl#isSuspended(org.eclipse.cdt.dsf.debug.service.IRunControl.IExecutionDMContext)
+     */
+    @Override
+    public boolean isSuspended(IExecutionDMContext context) {
+        return false;
+    }
+
+    /* (non-Javadoc)
+     * @see org.eclipse.cdt.dsf.debug.service.IRunControl#getExecutionData(org.eclipse.cdt.dsf.debug.service.IRunControl.IExecutionDMContext, org.eclipse.cdt.dsf.concurrent.DataRequestMonitor)
+     */
+    @Override
+    public void getExecutionData(IExecutionDMContext dmc, DataRequestMonitor<IExecutionDMData> rm) {
+        rm.done(fModelService.getExecutionData(dmc));
+    }
+
+    /* (non-Javadoc)
+     * @see org.eclipse.cdt.dsf.debug.service.IRunControl#getExecutionContexts(org.eclipse.cdt.dsf.debug.service.IRunControl.IContainerDMContext, org.eclipse.cdt.dsf.concurrent.DataRequestMonitor)
+     */
+    @Override
+    public void getExecutionContexts(IContainerDMContext c, DataRequestMonitor<IExecutionDMContext[]> rm) {
+        rm.done(new Status(IStatus.ERROR, DsfTraceCorePlugin.PLUGIN_ID, NOT_SUPPORTED, "Operation not supported", null)); //$NON-NLS-1$
+    }
+
+    /* (non-Javadoc)
+     * @see org.eclipse.cdt.dsf.debug.service.IRunControl#canResume(org.eclipse.cdt.dsf.debug.service.IRunControl.IExecutionDMContext, org.eclipse.cdt.dsf.concurrent.DataRequestMonitor)
+     */
+    @Override
+    public void canResume(IExecutionDMContext context, DataRequestMonitor<Boolean> rm) {
+        rm.done(false);
+    }
+
+    /* (non-Javadoc)
+     * @see org.eclipse.cdt.dsf.debug.service.IRunControl#canSuspend(org.eclipse.cdt.dsf.debug.service.IRunControl.IExecutionDMContext, org.eclipse.cdt.dsf.concurrent.DataRequestMonitor)
+     */
+    @Override
+    public void canSuspend(IExecutionDMContext context, DataRequestMonitor<Boolean> rm) {
+        rm.done(false);
+    }
+
+    /* (non-Javadoc)
+     * @see org.eclipse.cdt.dsf.debug.service.IRunControl#resume(org.eclipse.cdt.dsf.debug.service.IRunControl.IExecutionDMContext, org.eclipse.cdt.dsf.concurrent.RequestMonitor)
+     */
+    @Override
+    public void resume(IExecutionDMContext context, RequestMonitor rm) {
+        rm.done(new Status(IStatus.ERROR, DsfTraceCorePlugin.PLUGIN_ID, NOT_SUPPORTED, "Operation not supported", null)); //$NON-NLS-1$
+    }
+
+    /* (non-Javadoc)
+     * @see org.eclipse.cdt.dsf.debug.service.IRunControl#suspend(org.eclipse.cdt.dsf.debug.service.IRunControl.IExecutionDMContext, org.eclipse.cdt.dsf.concurrent.RequestMonitor)
+     */
+    @Override
+    public void suspend(IExecutionDMContext context, RequestMonitor rm) {
+        rm.done(new Status(IStatus.ERROR, DsfTraceCorePlugin.PLUGIN_ID, NOT_SUPPORTED, "Operation not supported", null)); //$NON-NLS-1$
+    }
+
+    /* (non-Javadoc)
+     * @see org.eclipse.cdt.dsf.debug.service.IRunControl#isStepping(org.eclipse.cdt.dsf.debug.service.IRunControl.IExecutionDMContext)
+     */
+    @Override
+    public boolean isStepping(IExecutionDMContext context) {
+        return false;
+    }
+
+    /* (non-Javadoc)
+     * @see org.eclipse.cdt.dsf.debug.service.IRunControl#canStep(org.eclipse.cdt.dsf.debug.service.IRunControl.IExecutionDMContext, org.eclipse.cdt.dsf.debug.service.IRunControl.StepType, org.eclipse.cdt.dsf.concurrent.DataRequestMonitor)
+     */
+    @Override
+    public void canStep(IExecutionDMContext context, StepType stepType, DataRequestMonitor<Boolean> rm) {
+        rm.setData(false);
+    }
+
+    /* (non-Javadoc)
+     * @see org.eclipse.cdt.dsf.debug.service.IRunControl#step(org.eclipse.cdt.dsf.debug.service.IRunControl.IExecutionDMContext, org.eclipse.cdt.dsf.debug.service.IRunControl.StepType, org.eclipse.cdt.dsf.concurrent.RequestMonitor)
+     */
+    @Override
+    public void step(IExecutionDMContext context, StepType stepType, RequestMonitor rm) {
+        rm.done(new Status(IStatus.ERROR, DsfTraceCorePlugin.PLUGIN_ID, NOT_SUPPORTED, "Operation not supported", null)); //$NON-NLS-1$
+    }
+}

--- a/org.eclipse.tracecompass.dsf.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.tracecompass.dsf.ui/META-INF/MANIFEST.MF
@@ -17,4 +17,6 @@ Require-Bundle: org.eclipse.cdt.dsf.gdb.multicorevisualizer.ui,
  org.eclipse.cdt.dsf.ui,
  org.eclipse.tracecompass.dsf.core,
  org.eclipse.tracecompass.tmf.core,
- org.eclipse.core.runtime
+ org.eclipse.core.runtime,
+ org.eclipse.tracecompass.analysis.os.linux.core,
+ org.eclipse.jdt.annotation

--- a/org.eclipse.tracecompass.dsf.ui/src/org/eclipse/tracecompass/internal/dsf/ui/visualizer/TraceMulticoreVisualizer.java
+++ b/org.eclipse.tracecompass.dsf.ui/src/org/eclipse/tracecompass/internal/dsf/ui/visualizer/TraceMulticoreVisualizer.java
@@ -133,15 +133,17 @@ public class TraceMulticoreVisualizer extends MulticoreVisualizer {
 
     @Override
     public void setLoadMetersEnabled(boolean enabled) {
-        if (m_loadMetersEnabled == enabled) {
-            return;
+        if (fDataModel != null) {
+            if (m_loadMetersEnabled == enabled) {
+                return;
+            }
+            m_loadMetersEnabled = enabled;
+            // save load meter enablement in model
+            fDataModel.setLoadMetersEnabled(m_loadMetersEnabled);
+            disposeLoadMeterTimer();
+            // No polling timers for Tracing
+            // initializeLoadMeterTimer();
         }
-        m_loadMetersEnabled = enabled;
-        // save load meter enablement in model
-        fDataModel.setLoadMetersEnabled(m_loadMetersEnabled);
-        disposeLoadMeterTimer();
-        // No polling timers for Tracing
-        // initializeLoadMeterTimer();
     }
 
 }

--- a/org.eclipse.tracecompass.dsf.ui/src/org/eclipse/tracecompass/internal/dsf/ui/visualizer/TraceMulticoreVisualizer.java
+++ b/org.eclipse.tracecompass.dsf.ui/src/org/eclipse/tracecompass/internal/dsf/ui/visualizer/TraceMulticoreVisualizer.java
@@ -110,7 +110,8 @@ public class TraceMulticoreVisualizer extends MulticoreVisualizer {
     @TmfSignalHandler
     public void timeSelected(TmfTimeSynchSignal signal) {
         setLoadMetersEnabled(true);
-        updateLoads();
+        // Refresh the data model
+        update();
     }
 
     /**
@@ -120,7 +121,8 @@ public class TraceMulticoreVisualizer extends MulticoreVisualizer {
     @TmfSignalHandler
     public void timeRangeSelected(TmfRangeSynchSignal signal) {
         setLoadMetersEnabled(true);
-        updateLoads();
+        // Refresh the data model
+        update();
     }
 
     /**

--- a/org.eclipse.tracecompass.dsf.ui/src/org/eclipse/tracecompass/internal/dsf/ui/visualizer/TraceMulticoreVisualizer.java
+++ b/org.eclipse.tracecompass.dsf.ui/src/org/eclipse/tracecompass/internal/dsf/ui/visualizer/TraceMulticoreVisualizer.java
@@ -11,24 +11,39 @@
  *******************************************************************************/
 package org.eclipse.tracecompass.internal.dsf.ui.visualizer;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.eclipse.cdt.dsf.gdb.multicorevisualizer.internal.ui.view.Messages;
 import org.eclipse.cdt.dsf.gdb.multicorevisualizer.internal.ui.view.MulticoreVisualizer;
 import org.eclipse.cdt.dsf.service.DsfSession;
 import org.eclipse.cdt.visualizer.ui.canvas.GraphicCanvas;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.tracecompass.analysis.os.linux.core.kernelanalysis.KernelAnalysis;
 import org.eclipse.tracecompass.internal.dsf.core.DsfTraceSessionManager;
+import org.eclipse.tracecompass.statesystem.core.ITmfStateSystem;
 import org.eclipse.tracecompass.tmf.core.signal.TmfRangeSynchSignal;
 import org.eclipse.tracecompass.tmf.core.signal.TmfSignalHandler;
 import org.eclipse.tracecompass.tmf.core.signal.TmfSignalManager;
 import org.eclipse.tracecompass.tmf.core.signal.TmfTimeSynchSignal;
+import org.eclipse.tracecompass.tmf.core.signal.TmfTraceClosedSignal;
+import org.eclipse.tracecompass.tmf.core.signal.TmfTraceOpenedSignal;
 import org.eclipse.tracecompass.tmf.core.signal.TmfTraceSelectedSignal;
+import org.eclipse.tracecompass.tmf.core.statesystem.TmfStateSystemAnalysisModule;
 import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
 import org.eclipse.tracecompass.tmf.core.trace.TmfTraceManager;
 
 /** */
 @SuppressWarnings("restriction")
 public class TraceMulticoreVisualizer extends MulticoreVisualizer {
+    // Timeout between updates in the build thread in ms
+    private static final long BUILD_UPDATE_TIMEOUT = 500;
+    // Map to track the polling threads for trace parsing completion
+    private final Map<ITmfTrace, BuildThread> fBuildThreadMap = new HashMap<>();
 
     /**
      *
@@ -39,7 +54,7 @@ public class TraceMulticoreVisualizer extends MulticoreVisualizer {
 
     /** Returns non-localized unique name for this visualizer. */
     @Override
-    public String getName() {
+    public @NonNull String getName() {
         return "tracecompass"; //$NON-NLS-1$
     }
 
@@ -101,6 +116,92 @@ public class TraceMulticoreVisualizer extends MulticoreVisualizer {
         updateDebugViewListener();
 
         return result;
+    }
+
+    /**
+     * @param signal -
+     */
+    @TmfSignalHandler
+    public void traceOpened(TmfTraceOpenedSignal signal) {
+        ITmfTrace trace = signal.getTrace();
+        if (trace == null) {
+            return;
+        }
+
+        // Create a polling thread to know when the trace has been parsed
+        BuildThread buildThread = new BuildThread(trace, getName());
+
+        synchronized (fBuildThreadMap) {
+            fBuildThreadMap.put(trace, buildThread);
+        }
+
+        buildThread.start();
+    }
+
+    /**
+     * @param signal -
+     */
+    @TmfSignalHandler
+    public void traceClosed(TmfTraceClosedSignal signal) {
+        ITmfTrace trace = signal.getTrace();
+
+        // Remove the polling thread from the tracking list
+        BuildThread thread = null;
+        synchronized (fBuildThreadMap) {
+            thread = fBuildThreadMap.remove(trace);
+        }
+
+        if (thread != null) {
+            thread.cancel();
+        }
+    }
+
+    private class BuildThread extends Thread {
+        private final @NonNull ITmfTrace fBuildTrace;
+        private final @NonNull IProgressMonitor fMonitor;
+
+        public BuildThread(final @NonNull ITmfTrace trace, final @NonNull String name) {
+            super(name + " build"); //$NON-NLS-1$
+            fBuildTrace = trace;
+            fMonitor = new NullProgressMonitor();
+        }
+
+        @Override
+        public void run() {
+            buildEventList(fBuildTrace, fMonitor);
+            // trace build is done, remove it from the tracking list
+            synchronized (fBuildThreadMap) {
+                fBuildThreadMap.remove(fBuildTrace);
+            }
+        }
+
+        public void cancel() {
+            fMonitor.setCanceled(true);
+        }
+    }
+
+    private void buildEventList(@NonNull ITmfTrace trace, @NonNull IProgressMonitor monitor) {
+        ITmfStateSystem ssq = TmfStateSystemAnalysisModule.getStateSystem(trace, KernelAnalysis.ID);
+        if (ssq == null) {
+            return;
+        }
+
+        boolean complete = false;
+
+        // Poll until build completion of cancellation
+        while (!complete) {
+            if (monitor.isCanceled()) {
+                return;
+            }
+
+            complete = ssq.waitUntilBuilt(BUILD_UPDATE_TIMEOUT);
+            if (ssq.isCancelled()) {
+                return;
+            }
+        }
+
+        // The trace is now fully parsed
+        update();
     }
 
     /**


### PR DESCRIPTION
- Added function to resolve thread id and executable name
- Trace closing triggering services and session termination
- Always initialize start time upon time re-selection
- getCores updated to resolve all cached cores when no context is provided

Baseline updated as we may need to change the structure to update the visualizer model 
for each time re-selection, this is needed as we can not rely on GDB events to update the dynamics of the threads.
