### PR TITLE
Fixed npe and editable transition name

### DIFF
--- a/tmf/org.eclipse.tracecompass.tmf.statemachine.graphiti/src/org/eclipse/tracecompass/tmf/statemachine/features/TransitionCreateConnectionFeature.java
+++ b/tmf/org.eclipse.tracecompass.tmf.statemachine.graphiti/src/org/eclipse/tracecompass/tmf/statemachine/features/TransitionCreateConnectionFeature.java
@@ -22,9 +22,9 @@ import statemachine.StatemachineFactory;
 import statemachine.Transition;
 
 public class TransitionCreateConnectionFeature extends AbstractCreateConnectionFeature {
-	
-	private AbstractState targetState = null;
-	private AbstractState sourceState = null;
+
+	private AbstractState targetState;
+	private AbstractState sourceState;
 
 	public TransitionCreateConnectionFeature(IFeatureProvider fp) {
 		super(fp, "Transition", "Creates a new transition between two states");
@@ -32,8 +32,22 @@ public class TransitionCreateConnectionFeature extends AbstractCreateConnectionF
 
 	@Override
 	public boolean canCreate(ICreateConnectionContext context) {
+	    targetState = null;
+	    sourceState = null;
 		PictogramElement sourcePictogramElement = context.getSourcePictogramElement();
 		PictogramElement targetPictogramElement = context.getTargetPictogramElement();
+		if (sourcePictogramElement != null) {
+		    PictogramElement stateMachinePictogramElement = (PictogramElement) sourcePictogramElement.eContainer();
+		    Statemachine stateMachine = (Statemachine) getBusinessObjectForPictogramElement(stateMachinePictogramElement);
+		    if(stateMachine.getAssociatedAttribute() == null) {
+		        return false;
+		    }
+		}
+
+		if(getBusinessObjectForPictogramElement(targetPictogramElement) instanceof AbstractState) {
+		    AbstractState state = (AbstractState) getBusinessObjectForPictogramElement(sourcePictogramElement);
+		    state.getTransitions();
+		}
 
 		if (getBusinessObjectForPictogramElement(sourcePictogramElement) instanceof AbstractState && getBusinessObjectForPictogramElement(targetPictogramElement) instanceof AbstractState) {
 			targetState = (AbstractState) getBusinessObjectForPictogramElement(targetPictogramElement);

--- a/tmf/org.eclipse.tracecompass.tmf.statemachine.graphiti/src/org/eclipse/tracecompass/tmf/statemachine/property/TransitionSection.java
+++ b/tmf/org.eclipse.tracecompass.tmf.statemachine.graphiti/src/org/eclipse/tracecompass/tmf/statemachine/property/TransitionSection.java
@@ -151,6 +151,9 @@ public class TransitionSection extends GFPropertySection implements ITabbedPrope
     public void refresh() {
 		if(getTransition() != null) {
     		String TransitionName = getTransition().getName();
+    		if(TransitionName == "then" || TransitionName == "else") {
+    		    transitionNameText.setEnabled(false);
+    		}
     		transitionNameText.setText((TransitionName != null) ? TransitionName : "");
     		stateChangeTable.removeAll();
     		for (int i = 0; i < getTransition().getStateChange().size(); i++) {


### PR DESCRIPTION
Fixed npe when you create a transition and the statemachine attribute is
not set. Also the transition is now not editable if it a "then" or
"else" transition.

Signed-off-by: Simon Delisle simon.delisle@ericsson.com
